### PR TITLE
Build epistats counties

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,5 +19,5 @@ Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Encoding: UTF-8

--- a/R/EpiStats.R
+++ b/R/EpiStats.R
@@ -6,8 +6,8 @@
 #'              the probability of diagnosed HIV infection, for use in the EpiModelHIV
 #'              workflow.
 #'
-#' @param geog.lvl Specifies geographic feature for ARTnet statistics.
-#' @param geog.cat Specifies geographic stratum to base ARTnet statistics on.
+#' @param geog.lvl Specifies geographic level for ARTnet statistics.
+#' @param geog.cat Specifies one or more geographic strata within the level to base ARTnet statistics on.
 #' @param age.limits Upper and lower limit. Age range to subset ARTnet data by.
 #'        Default is 15 to 65.
 #' @param age.breaks Ages that define the upper age categories. Default is
@@ -43,18 +43,16 @@
 #'          division and complete geographic area respectively. Default value is "NULL",
 #'          indicating no geographic stratification.
 #'    \item \code{geog.cat}: given a geographic level above, \code{"geog.cat"}
-#'          is the desired feature(s) of interest. Acceptable values are based on the
-#'          chosen geographic level:
+#'          is a vector comprising the desired feature(s) of interest. If the
+#'          vector is of length 2+, data from the features will be combined
+#'          into one analysis. Acceptable values are based on the chosen geographic level:
 #'    \itemize{
 #'      \item \code{city}: \code{"Atlanta"}, \code{"Boston"}, \code{"Chicago"},
 #'            \code{"Dallas"}, \code{"Denver"}, \code{"Detroit"}, \code{"Houston"},
 #'            \code{"Los Angeles"}, \code{"Miami"}, \code{"New York City"},
 #'            \code{"Philadelphia"}, \code{"San Diego"}, \code{"San Franciso"},
 #'            \code{"Seattle"}, \code{"Washington DC"}
-#'      \item \code{county}: A vector of FIPS codes for the county or
-#'                    county equivalents to be included.  This is the only option that
-#'                    allows for an arbitrary number of geographical units to be explicitly combined
-#'                    into one analysis.
+#'      \item \code{county}: FIPS codes for the county or county equivalents to be included.
 #'      \item \code{state}: \code{"AK"}, \code{"AL"}, \code{"AR"}, \code{"AZ"},
 #'            \code{"CA"}, \code{"CO"}, \code{"CT"}, \code{"DC"}, \code{"DE"},
 #'            \code{"FL"}, \code{"GA"}, \code{"HI"}, \code{"IA"}, \code{"ID"},
@@ -94,12 +92,15 @@
 #' # Default age stratification
 #' epistats2 <- build_epistats(geog.lvl = "state", geog.cat = "WA")
 #'
+#' # Default age stratification, multiple states
+#' epistats3 <- build_epistats(geog.lvl = "state", geog.cat = c("ME", "NH", "VT"))
+
 #' # No race stratification
-#' epistats3 <- build_epistats(geog.lvl = "state", geog.cat = "GA",
+#' epistats4 <- build_epistats(geog.lvl = "state", geog.cat = "GA",
 #'                             race = FALSE)
 #'
 #' # Age and race stratification, for the municipality (not metro) of New York City
-#' epistats4 <- build_epistats(geog.lvl = "county",
+#' epistats5 <- build_epistats(geog.lvl = "county",
 #'                             geog.cat = c(36005, 36047, 36061, 36081, 36085), # FIPS codes for the 5 boroughs of NYC
 #'                             age.limits = c(20, 50),
 #'                             age.breaks = c(24, 34, 44))

--- a/R/EpiStats.R
+++ b/R/EpiStats.R
@@ -8,7 +8,7 @@
 #'
 #' @param geog.lvl Specifies geographic level for ARTnet statistics.
 #' @param geog.cat Specifies one or more geographic strata within the level to base
-#'        ARTnet statistics on. If the vector is of length 2+, data from the features
+#'        ARTnet statistics on. If the vector is of length 2+, data from the strata
 #'        will be combined into one analysis.
 #' @param age.limits Upper and lower limit. Age range to subset ARTnet data by.
 #'        Default is 15 to 65.
@@ -128,13 +128,17 @@ build_epistats <- function(geog.lvl = NULL, geog.cat = NULL, race = FALSE,
   geog_names <- c("city", "county", "state", "region", "division")
   if (!is.null(geog.lvl)) {
     if (!(geog.lvl %in% geog_names)) {
-      stop("Selected geographic feature must be one of: city, county, state, region or division")
+      stop("Selected geographic level must be one of: city, county, state, region or division")
     }
   }
 
   # Data Processing ---------------------------------------------------------
 
   # Geography
+  if (length(geog.lvl) > 1) {
+    stop("Only one geographical level may be chosen at a time.")
+  }
+
   if (!is.null(geog.lvl)) {
     if (geog.lvl == "city") {
       if (sum(geog.cat %in% unique(d$city))==0) {

--- a/R/EpiStats.R
+++ b/R/EpiStats.R
@@ -37,9 +37,9 @@
 #' @section Parameter Values:
 #' \itemize{
 #'   \item \code{geog.lvl}: level of geographic stratification desired. Acceptable
-#'          values are \code{"city"}, \code{"counties"}, \code{"state"}, \code{"region"}, and
+#'          values are \code{"city"}, \code{"county"}, \code{"state"}, \code{"region"}, and
 #'          \code{"division"} corresponding to the metropolitan statistical area,
-#'          counties, state, census region, census
+#'          county, state, census region, census
 #'          division and complete geographic area respectively. Default value is "NULL",
 #'          indicating no geographic stratification.
 #'    \item \code{geog.cat}: given a geographic level above, \code{"geog.cat"}
@@ -51,7 +51,7 @@
 #'            \code{"Los Angeles"}, \code{"Miami"}, \code{"New York City"},
 #'            \code{"Philadelphia"}, \code{"San Diego"}, \code{"San Franciso"},
 #'            \code{"Seattle"}, \code{"Washington DC"}
-#'      \item \code{counties}: A vector of FIPS codes for the counties or
+#'      \item \code{county}: A vector of FIPS codes for the county or
 #'                    county equivalents to be included.  This is the only option that
 #'                    allows for an arbitrary number of geographical units to be explicitly combined
 #'                    into one analysis.
@@ -99,7 +99,7 @@
 #'                             race = FALSE)
 #'
 #' # Age and race stratification, for the municipality (not metro) of New York City
-#' epistats4 <- build_epistats(geog.lvl = "counties",
+#' epistats4 <- build_epistats(geog.lvl = "county",
 #'                             geog.cat = c(36005, 36047, 36061, 36081, 36085), # FIPS codes for the 5 boroughs of NYC
 #'                             age.limits = c(20, 50),
 #'                             age.breaks = c(24, 34, 44))
@@ -124,39 +124,31 @@ build_epistats <- function(geog.lvl = NULL, geog.cat = NULL, race = FALSE,
 
   out <- list()
 
-  geog_names <- c("city", "counties", "state", "region", "division", "all")
+  geog_names <- c("city", "county", "state", "region", "division", "all")
   if (!is.null(geog.lvl)) {
     if (!(geog.lvl %in% geog_names)) {
-      stop("Selected geographic feature must be one of: city, counties, state, region or division")
+      stop("Selected geographic feature must be one of: city, county, state, region or division")
     }
   }
 
   # Data Processing ---------------------------------------------------------
 
   # Geography
-  if (length(geog.lvl) > 1) {
-    stop("Only one geographical factor may be chosen at a time.")
-  }
-
-  if (length(geog.cat) > 1 && !is.null(geog.lvl) && geog.lvl!='counties') {
-    stop("Only one value of geog.cat may be chosen at a time (for values of geog.lvl other than 'counties')")
-  }
-
   if (!is.null(geog.lvl)) {
     if (geog.lvl == "city") {
-      if (!(geog.cat %in% unique(d$city))) {
-        stop("City name not found")
+      if (sum(geog.cat %in% unique(d$city))==0) {
+        stop("None of the city names found in the data")
       }
       l <- suppressMessages(left_join(l, d[, c("AMIS_ID", "city2")]))
-      l$geogYN <- ifelse(l[, "city2"] == geog.cat, 1, 0)
+      l$geogYN <- ifelse(l[, "city2"] %in% geog.cat, 1, 0)
       l$geog <- l$city2
-      d$geogYN <- ifelse(d[, "city2"] == geog.cat, 1, 0)
+      d$geogYN <- ifelse(d[, "city2"] %in% geog.cat, 1, 0)
       d$geog <- d$city2
     }
 
-    if (geog.lvl == "counties") {
+    if (geog.lvl == "county") {
       if (sum(geog.cat %in% unique(d$COUNTYFIPS))==0) {
-         stop("None of the FIPS codes found")
+         stop("None of the county FIPS codes found in the data")
       }
       l <- suppressMessages(left_join(l, d[, c("AMIS_ID", "COUNTYFIPS")]))
       l$geogYN <- ifelse(l[, "COUNTYFIPS"] %in% geog.cat, 1, 0)
@@ -166,35 +158,35 @@ build_epistats <- function(geog.lvl = NULL, geog.cat = NULL, race = FALSE,
     }
 
     if (geog.lvl == "state") {
-      if (!(geog.cat %in% unique(d$State))) {
-        stop("State name not found")
+      if (sum(geog.cat %in% unique(d$State))==0) {
+        stop("None of the states found in the data")
       }
       l <- suppressMessages(left_join(l, d[, c("AMIS_ID", "State")]))
-      l$geogYN <- ifelse(l[, "State"] == geog.cat, 1, 0)
+      l$geogYN <- ifelse(l[, "State"] %in% geog.cat, 1, 0)
       l$geog <- l$State
-      d$geogYN <- ifelse(d[, "State"] == geog.cat, 1, 0)
+      d$geogYN <- ifelse(d[, "State"] %in% geog.cat, 1, 0)
       d$geog <- d$State
     }
 
     if (geog.lvl == "division") {
-      if (!(geog.cat %in% unique(d$DIVCODE))) {
-        stop("Division number not found")
+      if (sum(geog.cat %in% unique(d$DIVCODE))==0) {
+        stop("None of the census division codes found in the data")
       }
       l <- suppressMessages(left_join(l, d[, c("AMIS_ID", "DIVCODE")]))
-      l$geogYN <- ifelse(l[, "DIVCODE"] == geog.cat, 1, 0)
+      l$geogYN <- ifelse(l[, "DIVCODE"] %in% geog.cat, 1, 0)
       l$geog <- l$DIVCODE
-      d$geogYN <- ifelse(d[, "DIVCODE"] == geog.cat, 1, 0)
+      d$geogYN <- ifelse(d[, "DIVCODE"] %in% geog.cat, 1, 0)
       d$geog <- d$DIVCODE
     }
 
     if (geog.lvl == "region") {
-      if (!(geog.cat %in% unique(d$REGCODE))) {
-        stop("Regional code not found")
+      if (sum(geog.cat %in% unique(d$REGCODE))==0) {
+        stop("None of the census region codes found in the data")
       }
       l <- suppressMessages(left_join(l, d[, c("AMIS_ID", "REGCODE")]))
-      l$geogYN <- ifelse(l[, "REGCODE"] == geog.cat, 1, 0)
+      l$geogYN <- ifelse(l[, "REGCODE"] %in% geog.cat, 1, 0)
       l$geog <- l$REGCODE
-      d$geogYN <- ifelse(d[, "REGCODE"] == geog.cat, 1, 0)
+      d$geogYN <- ifelse(d[, "REGCODE"] %in% geog.cat, 1, 0)
       d$geog <- d$REGCODE
     }
   }

--- a/R/EpiStats.R
+++ b/R/EpiStats.R
@@ -7,7 +7,9 @@
 #'              workflow.
 #'
 #' @param geog.lvl Specifies geographic level for ARTnet statistics.
-#' @param geog.cat Specifies one or more geographic strata within the level to base ARTnet statistics on.
+#' @param geog.cat Specifies one or more geographic strata within the level to base
+#'        ARTnet statistics on. If the vector is of length 2+, data from the features
+#'        will be combined into one analysis.
 #' @param age.limits Upper and lower limit. Age range to subset ARTnet data by.
 #'        Default is 15 to 65.
 #' @param age.breaks Ages that define the upper age categories. Default is
@@ -39,13 +41,11 @@
 #'   \item \code{geog.lvl}: level of geographic stratification desired. Acceptable
 #'          values are \code{"city"}, \code{"county"}, \code{"state"}, \code{"region"}, and
 #'          \code{"division"} corresponding to the metropolitan statistical area,
-#'          county, state, census region, census
-#'          division and complete geographic area respectively. Default value is "NULL",
+#'          county, state, census region, and census
+#'          division, respectively. Default value is "NULL",
 #'          indicating no geographic stratification.
 #'    \item \code{geog.cat}: given a geographic level above, \code{"geog.cat"}
-#'          is a vector comprising the desired feature(s) of interest. If the
-#'          vector is of length 2+, data from the features will be combined
-#'          into one analysis. Acceptable values are based on the chosen geographic level:
+#'          is a vector comprising the desired feature(s) of interest. Acceptable values are based on the chosen geographic level:
 #'    \itemize{
 #'      \item \code{city}: \code{"Atlanta"}, \code{"Boston"}, \code{"Chicago"},
 #'            \code{"Dallas"}, \code{"Denver"}, \code{"Detroit"}, \code{"Houston"},
@@ -125,7 +125,7 @@ build_epistats <- function(geog.lvl = NULL, geog.cat = NULL, race = FALSE,
 
   out <- list()
 
-  geog_names <- c("city", "county", "state", "region", "division", "all")
+  geog_names <- c("city", "county", "state", "region", "division")
   if (!is.null(geog.lvl)) {
     if (!(geog.lvl %in% geog_names)) {
       stop("Selected geographic feature must be one of: city, county, state, region or division")
@@ -191,6 +191,8 @@ build_epistats <- function(geog.lvl = NULL, geog.cat = NULL, race = FALSE,
       d$geog <- d$REGCODE
     }
   }
+
+
 
   # Age Processing
 

--- a/man/build_epistats.Rd
+++ b/man/build_epistats.Rd
@@ -30,10 +30,10 @@ Default is 15 to 65.}
 (35, 45], (45, 55], (55, 65], (65, 100].}
 
 \item{init.hiv.prev}{Initial HIV prevalence of estimated model, vector of size
-.        three pertaining to prevalence among three racial classes (black,
-        Hispanic and white respectively). If \code{init.hiv.prev = NULL},
-        ARTnet will handle calculation of prevalence through ARTnet data.
-        Note: if `\code{race = FALSE}, prevalence vector must still be supplied.}
+three pertaining to prevalence among three racial classes (black,
+Hispanic and white respectively). If \code{init.hiv.prev = NULL},
+ARTnet will handle calculation of prevalence through ARTnet data.
+Note: if `\code{race = FALSE}, prevalence vector must still be supplied.}
 
 \item{time.unit}{Specifies time unit for ARTnet statistics. Default is 7 for
 weekly time units. Inputs are by days with a maximum of 30 days.
@@ -61,12 +61,13 @@ values for each input parameter are provided below.
 
 \itemize{
   \item \code{geog.lvl}: level of geographic stratification desired. Acceptable
-         values are \code{"city"}, \code{"state"}, \code{"region"}, and
-         \code{"division"} corresponding to city, state, census region, census
+         values are \code{"city"}, \code{"counties"}, \code{"state"}, \code{"region"}, and
+         \code{"division"} corresponding to the metropolitan statistical area,
+         counties, state, census region, census
          division and complete geographic area respectively. Default value is "NULL",
          indicating no geographic stratification.
    \item \code{geog.cat}: given a geographic level above, \code{"geog.cat"}
-         is the desired feature of interest. Acceptable values are based on the
+         is the desired feature(s) of interest. Acceptable values are based on the
          chosen geographic level:
    \itemize{
      \item \code{city}: \code{"Atlanta"}, \code{"Boston"}, \code{"Chicago"},
@@ -74,6 +75,10 @@ values for each input parameter are provided below.
            \code{"Los Angeles"}, \code{"Miami"}, \code{"New York City"},
            \code{"Philadelphia"}, \code{"San Diego"}, \code{"San Franciso"},
            \code{"Seattle"}, \code{"Washington DC"}
+     \item \code{counties}: A vector of FIPS codes for the counties or
+                   county equivalents to be included.  This is the only option that
+                   allows for an arbitrary number of geographical units to be explicitly combined
+                   into one analysis.
      \item \code{state}: \code{"AK"}, \code{"AL"}, \code{"AR"}, \code{"AZ"},
            \code{"CA"}, \code{"CO"}, \code{"CT"}, \code{"DC"}, \code{"DE"},
            \code{"FL"}, \code{"GA"}, \code{"HI"}, \code{"IA"}, \code{"ID"},
@@ -105,7 +110,7 @@ values for each input parameter are provided below.
 }
 
 \examples{
-# Age and geographic stratification, for the city of Atlanta
+# Age and geographic stratification, for the Atlanta metropolitan statistical area
 epistats1 <- build_epistats(geog.lvl = "city",
                             geog.cat = "Atlanta",
                             age.limits = c(20, 50),
@@ -117,5 +122,12 @@ epistats2 <- build_epistats(geog.lvl = "state", geog.cat = "WA")
 # No race stratification
 epistats3 <- build_epistats(geog.lvl = "state", geog.cat = "GA",
                             race = FALSE)
+
+# Age and race stratification, for the municipality (not metro) of New York City
+epistats4 <- build_epistats(geog.lvl = "counties",
+                            geog.cat = c(36005, 36047, 36061, 36081, 36085), # FIPS codes for the 5 boroughs of NYC
+                            age.limits = c(20, 50),
+                            age.breaks = c(24, 34, 44))
+
 
 }

--- a/man/build_epistats.Rd
+++ b/man/build_epistats.Rd
@@ -18,7 +18,9 @@ build_epistats(
 \arguments{
 \item{geog.lvl}{Specifies geographic level for ARTnet statistics.}
 
-\item{geog.cat}{Specifies one or more geographic strata within the level to base ARTnet statistics on.}
+\item{geog.cat}{Specifies one or more geographic strata within the level to base
+ARTnet statistics on. If the vector is of length 2+, data from the features
+will be combined into one analysis.}
 
 \item{race}{Whether to stratify by racial status. Default is TRUE.}
 
@@ -63,13 +65,11 @@ values for each input parameter are provided below.
   \item \code{geog.lvl}: level of geographic stratification desired. Acceptable
          values are \code{"city"}, \code{"county"}, \code{"state"}, \code{"region"}, and
          \code{"division"} corresponding to the metropolitan statistical area,
-         county, state, census region, census
-         division and complete geographic area respectively. Default value is "NULL",
+         county, state, census region, and census
+         division, respectively. Default value is "NULL",
          indicating no geographic stratification.
    \item \code{geog.cat}: given a geographic level above, \code{"geog.cat"}
-         is a vector comprising the desired feature(s) of interest. If the
-         vector is of length 2+, data from the features will be combined
-         into one analysis. Acceptable values are based on the chosen geographic level:
+         is a vector comprising the desired feature(s) of interest. Acceptable values are based on the chosen geographic level:
    \itemize{
      \item \code{city}: \code{"Atlanta"}, \code{"Boston"}, \code{"Chicago"},
            \code{"Dallas"}, \code{"Denver"}, \code{"Detroit"}, \code{"Houston"},

--- a/man/build_epistats.Rd
+++ b/man/build_epistats.Rd
@@ -16,9 +16,9 @@ build_epistats(
 )
 }
 \arguments{
-\item{geog.lvl}{Specifies geographic feature for ARTnet statistics.}
+\item{geog.lvl}{Specifies geographic level for ARTnet statistics.}
 
-\item{geog.cat}{Specifies geographic stratum to base ARTnet statistics on.}
+\item{geog.cat}{Specifies one or more geographic strata within the level to base ARTnet statistics on.}
 
 \item{race}{Whether to stratify by racial status. Default is TRUE.}
 
@@ -61,24 +61,22 @@ values for each input parameter are provided below.
 
 \itemize{
   \item \code{geog.lvl}: level of geographic stratification desired. Acceptable
-         values are \code{"city"}, \code{"counties"}, \code{"state"}, \code{"region"}, and
+         values are \code{"city"}, \code{"county"}, \code{"state"}, \code{"region"}, and
          \code{"division"} corresponding to the metropolitan statistical area,
-         counties, state, census region, census
+         county, state, census region, census
          division and complete geographic area respectively. Default value is "NULL",
          indicating no geographic stratification.
    \item \code{geog.cat}: given a geographic level above, \code{"geog.cat"}
-         is the desired feature(s) of interest. Acceptable values are based on the
-         chosen geographic level:
+         is a vector comprising the desired feature(s) of interest. If the
+         vector is of length 2+, data from the features will be combined
+         into one analysis. Acceptable values are based on the chosen geographic level:
    \itemize{
      \item \code{city}: \code{"Atlanta"}, \code{"Boston"}, \code{"Chicago"},
            \code{"Dallas"}, \code{"Denver"}, \code{"Detroit"}, \code{"Houston"},
            \code{"Los Angeles"}, \code{"Miami"}, \code{"New York City"},
            \code{"Philadelphia"}, \code{"San Diego"}, \code{"San Franciso"},
            \code{"Seattle"}, \code{"Washington DC"}
-     \item \code{counties}: A vector of FIPS codes for the counties or
-                   county equivalents to be included.  This is the only option that
-                   allows for an arbitrary number of geographical units to be explicitly combined
-                   into one analysis.
+     \item \code{county}: FIPS codes for the county or county equivalents to be included.
      \item \code{state}: \code{"AK"}, \code{"AL"}, \code{"AR"}, \code{"AZ"},
            \code{"CA"}, \code{"CO"}, \code{"CT"}, \code{"DC"}, \code{"DE"},
            \code{"FL"}, \code{"GA"}, \code{"HI"}, \code{"IA"}, \code{"ID"},
@@ -119,12 +117,14 @@ epistats1 <- build_epistats(geog.lvl = "city",
 # Default age stratification
 epistats2 <- build_epistats(geog.lvl = "state", geog.cat = "WA")
 
+# Default age stratification, multiple states
+epistats3 <- build_epistats(geog.lvl = "state", geog.cat = c("ME", "NH", "VT"))
 # No race stratification
-epistats3 <- build_epistats(geog.lvl = "state", geog.cat = "GA",
+epistats4 <- build_epistats(geog.lvl = "state", geog.cat = "GA",
                             race = FALSE)
 
 # Age and race stratification, for the municipality (not metro) of New York City
-epistats4 <- build_epistats(geog.lvl = "counties",
+epistats5 <- build_epistats(geog.lvl = "county",
                             geog.cat = c(36005, 36047, 36061, 36081, 36085), # FIPS codes for the 5 boroughs of NYC
                             age.limits = c(20, 50),
                             age.breaks = c(24, 34, 44))

--- a/man/build_epistats.Rd
+++ b/man/build_epistats.Rd
@@ -19,7 +19,7 @@ build_epistats(
 \item{geog.lvl}{Specifies geographic level for ARTnet statistics.}
 
 \item{geog.cat}{Specifies one or more geographic strata within the level to base
-ARTnet statistics on. If the vector is of length 2+, data from the features
+ARTnet statistics on. If the vector is of length 2+, data from the strata
 will be combined into one analysis.}
 
 \item{race}{Whether to stratify by racial status. Default is TRUE.}

--- a/vignettes/ARTnetIntro.Rmd
+++ b/vignettes/ARTnetIntro.Rmd
@@ -47,7 +47,7 @@ epistats4 <- build_epistats(geog.lvl = "division", geog.cat = "5", init.hiv.prev
 epistats5 <- build_epistats(geog.lvl = "region", geog.cat = "3", init.hiv.prev = c(0.17, 0.17, 0.17))
 ```
 
-If no geographic stratification is specified, `geog.lvl = NULL`, and no geopgraphic stratification is done.
+If no geographic stratification is specified, `geog.lvl = NULL`, and no geographic stratification is done.
 
 ```{r }
 epistats6 <- build_epistats()


### PR DESCRIPTION
(1) adds `county` as a `geog.lvl` option, with FIPS codes as acceptable values for `geog.cat`
(2) generalizes all levels to allow for vectors instead of only one value
(3) removes `geog.lvl='all'` as an option since this is redundant with `NULL` and was never fully implemented
(4) updates docs tro reflect 1-3, and adds examples

