### PR TITLE
Prediction with geog yn

### DIFF
--- a/R/EpiStats.R
+++ b/R/EpiStats.R
@@ -2,7 +2,7 @@
 #' @title Statistical Models for Act Rates, Condom Use, and Starting HIV Prevalence
 #'
 #' @description Builds statistical models governing act rates and probability of
-#'              condom use among main, casual and one-of sexual partnerships, and
+#'              condom use among main, casual and one-time sexual partnerships, and
 #'              the probability of diagnosed HIV infection, for use in the EpiModelHIV
 #'              workflow.
 #'
@@ -52,7 +52,11 @@
 #'            \code{"Los Angeles"}, \code{"Miami"}, \code{"New York City"},
 #'            \code{"Philadelphia"}, \code{"San Diego"}, \code{"San Franciso"},
 #'            \code{"Seattle"}, \code{"Washington DC"}
-#'      \item \code{county}: FIPS codes for the county or county equivalents to be included.
+#'      \item \code{county}: FIPS codes for the county or county equivalents to
+#'      be included. Be aware that selecting a single county or a set of smaller
+#'      counties may lead to insufficient data being used to estimate the model;
+#'      if the sample lacks sufficient behavioral diversity (e.g. if nobody
+#'      reports 2+ ongoing casual partners), an error may result.
 #'      \item \code{state}: \code{"AK"}, \code{"AL"}, \code{"AR"}, \code{"AZ"},
 #'            \code{"CA"}, \code{"CO"}, \code{"CT"}, \code{"DC"}, \code{"DE"},
 #'            \code{"FL"}, \code{"GA"}, \code{"HI"}, \code{"IA"}, \code{"ID"},

--- a/R/NetParams.R
+++ b/R/NetParams.R
@@ -213,11 +213,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$md.main <- as.numeric(pred)
   } else {
-    mod <- glm(deg.main ~ geog,
+    mod <- glm(deg.main ~ geogYN,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$md.main <- as.numeric(pred)
@@ -244,11 +244,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$nm.age.grp <- as.numeric(pred)
   } else {
-    mod <- glm(same.age.grp ~ geog + index.age.grp,
+    mod <- glm(same.age.grp ~ geogYN + index.age.grp,
                data = lmain, family = binomial())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, index.age.grp = 1:age.grps)
+    dat <- data.frame(geogYN = 1, index.age.grp = 1:age.grps)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$nm.age.grp <- as.numeric(pred)
@@ -268,10 +268,10 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$absdiff.age <- as.numeric(pred)
   } else {
-    mod <- lm(ad ~ geog, data = lmain)
+    mod <- lm(ad ~ geogYN, data = lmain)
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$absdiff.age <- as.numeric(pred)
@@ -288,10 +288,10 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$absdiff.sqrt.age <- as.numeric(pred)
   } else {
-    mod <- lm(ad.sr ~ geog, data = lmain)
+    mod <- lm(ad.sr ~ geogYN, data = lmain)
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$absdiff.sqrt.age <- as.numeric(pred)
@@ -313,11 +313,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$nf.age.grp <- as.numeric(pred)
   } else {
-    mod <- glm(deg.main ~ geog + age.grp + sqrt(age.grp),
+    mod <- glm(deg.main ~ geogYN + age.grp + sqrt(age.grp),
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, age.grp = 1:age.grps)
+    dat <- data.frame(geogYN = 1, age.grp = 1:age.grps)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$nf.age.grp <- as.numeric(pred)
@@ -339,11 +339,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$main$nm.race <- as.numeric(pred)
     } else {
-      mod <- glm(same.race ~ geog + as.factor(race.cat3),
+      mod <- glm(same.race ~ geogYN + as.factor(race.cat3),
                  data = lmain, family = binomial())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat, race.cat3 = 1:3)
+      dat <- data.frame(geogYN = 1, race.cat3 = 1:3)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$main$nm.race <- as.numeric(pred)
@@ -361,11 +361,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$main$nm.race_diffF <- as.numeric(pred)
     } else {
-      mod <- glm(same.race ~ geog,
+      mod <- glm(same.race ~ geogYN,
                  data = lmain, family = binomial())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat)
+      dat <- data.frame(geogYN = 1)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$main$nm.race_diffF <- as.numeric(pred)
@@ -402,11 +402,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
       #                       design = d.design,
       #                       family = poisson())
 
-      mod <- glm(deg.main ~ geog + as.factor(race.cat3),
+      mod <- glm(deg.main ~ geogYN + as.factor(race.cat3),
                  data = d, family = poisson())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat, race.cat3 = 1:3)
+      dat <- data.frame(geogYN = 1, race.cat3 = 1:3)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$main$nf.race <- as.numeric(pred)
@@ -428,16 +428,16 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
     deg.casl.dist <- prop.table(table(d$deg.casl))
     out$main$deg.casl.dist <- as.numeric(deg.casl.dist)
   } else {
-    mod <- glm(deg.main ~ geog + deg.casl,
+    mod <- glm(deg.main ~ geogYN + deg.casl,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, deg.casl = sort(unique(d$deg.casl)))
+    dat <- data.frame(geogYN = 1, deg.casl = sort(unique(d$deg.casl)))
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$nf.deg.casl <- as.numeric(pred)
 
-    deg.casl.dist <- prop.table(table(d$deg.casl[d$geog == geog.cat]))
+    deg.casl.dist <- prop.table(table(d$deg.casl[d$geogYN == 1]))
     out$main$deg.casl.dist <- as.numeric(deg.casl.dist)
   }
 
@@ -453,11 +453,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$concurrent <- as.numeric(pred)
   } else {
-    mod <- glm(deg.main.conc ~ geog,
+    mod <- glm(deg.main.conc ~ geogYN,
                data = d, family = binomial())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$concurrent <- as.numeric(pred)
@@ -476,11 +476,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$main$nf.diag.status <- as.numeric(pred)
   } else {
-    mod <- glm(deg.main ~ geog + hiv2,
+    mod <- glm(deg.main ~ geogYN + hiv2,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, hiv2 = 0:1)
+    dat <- data.frame(geogYN = 1, hiv2 = 0:1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$main$nf.diag.status <- as.numeric(pred)
@@ -504,7 +504,7 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
       filter(RAI == 1 | IAI == 1) %>%
       filter(index.age.grp < 6) %>%
       filter(ongoing2 == 1) %>%
-      filter(geog == geog.cat) %>%
+      filter(geogYN == 1) %>%
       summarise(mean.dur = mean(duration.time, na.rm = TRUE),
                 median.dur = median(duration.time, na.rm = TRUE)) %>%
       as.data.frame()
@@ -583,11 +583,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$md.casl <- as.numeric(pred)
   } else {
-    mod <- glm(deg.casl ~ geog,
+    mod <- glm(deg.casl ~ geogYN,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$md.casl <- as.numeric(pred)
@@ -613,11 +613,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$nm.age.grp <- as.numeric(pred)
   } else {
-    mod <- glm(same.age.grp ~ geog + index.age.grp,
+    mod <- glm(same.age.grp ~ geogYN + index.age.grp,
                data = lcasl, family = binomial())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, index.age.grp = 1:age.grps)
+    dat <- data.frame(geogYN = 1, index.age.grp = 1:age.grps)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$nm.age.grp <- as.numeric(pred)
@@ -637,10 +637,10 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$absdiff.age <- as.numeric(pred)
   } else {
-    mod <- lm(ad ~ geog, data = lcasl)
+    mod <- lm(ad ~ geogYN, data = lcasl)
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$absdiff.age <- as.numeric(pred)
@@ -657,10 +657,10 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$absdiff.sqrt.age <- as.numeric(pred)
   } else {
-    mod <- lm(ad.sr ~ geog, data = lcasl)
+    mod <- lm(ad.sr ~ geogYN, data = lcasl)
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$absdiff.sqrt.age <- as.numeric(pred)
@@ -682,11 +682,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$nf.age.grp <- as.numeric(pred)
   } else {
-    mod <- glm(deg.casl ~ geog + age.grp + sqrt(age.grp),
+    mod <- glm(deg.casl ~ geogYN + age.grp + sqrt(age.grp),
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, age.grp = 1:age.grps)
+    dat <- data.frame(geogYN = 1, age.grp = 1:age.grps)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$nf.age.grp <- as.numeric(pred)
@@ -711,11 +711,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$casl$nm.race <- as.numeric(pred)
     } else {
-      mod <- glm(same.race ~ geog + as.factor(race.cat3),
+      mod <- glm(same.race ~ geogYN + as.factor(race.cat3),
                  data = lcasl, family = binomial())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat, race.cat3 = 1:3)
+      dat <- data.frame(geogYN = 1, race.cat3 = 1:3)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$casl$nm.race <- as.numeric(pred)
@@ -733,11 +733,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$casl$nm.race_diffF <- as.numeric(pred)
     } else {
-      mod <- glm(same.race ~ geog,
+      mod <- glm(same.race ~ geogYN,
                  data = lcasl, family = binomial())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat)
+      dat <- data.frame(geogYN = 1)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$casl$nm.race_diffF <- as.numeric(pred)
@@ -764,11 +764,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
       #                      design = d.design,
       #                      family = poisson())
 
-      mod <- glm(deg.casl ~ geog + as.factor(race.cat3),
+      mod <- glm(deg.casl ~ geogYN + as.factor(race.cat3),
                  data = d, family = poisson())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat, race.cat3 = 1:3)
+      dat <- data.frame(geogYN = 1, race.cat3 = 1:3)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$casl$nf.race <- as.numeric(pred)
@@ -790,16 +790,16 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
     deg.main.dist <- prop.table(table(d$deg.main))
     out$casl$deg.main.dist <- as.numeric(deg.main.dist)
   } else {
-    mod <- glm(deg.casl ~ geog + deg.main,
+    mod <- glm(deg.casl ~ geogYN + deg.main,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, deg.main = 0:2)
+    dat <- data.frame(geogYN = 1, deg.main = 0:2)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$nf.deg.main <- as.numeric(pred)
 
-    deg.main.dist <- prop.table(table(d$deg.main[d$geog == geog.cat]))
+    deg.main.dist <- prop.table(table(d$deg.main[d$geogYN == 1]))
     out$casl$deg.main.dist <- as.numeric(deg.main.dist)
   }
 
@@ -815,11 +815,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$concurrent <- as.numeric(pred)
   } else {
-    mod <- glm(deg.casl.conc ~ geog,
+    mod <- glm(deg.casl.conc ~ geogYN,
                data = d, family = binomial())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$concurrent <- as.numeric(pred)
@@ -838,11 +838,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$casl$nf.diag.status <- as.numeric(pred)
   } else {
-    mod <- glm(deg.casl ~ geog + hiv2,
+    mod <- glm(deg.casl ~ geogYN + hiv2,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, hiv2 = 0:1)
+    dat <- data.frame(geogYN = 1, hiv2 = 0:1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$casl$nf.diag.status <- as.numeric(pred)
@@ -866,7 +866,7 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
       filter(RAI == 1 | IAI == 1) %>%
       filter(index.age.grp < 6) %>%
       filter(ongoing2 == 1) %>%
-      filter(geog == geog.cat) %>%
+      filter(geogYN == 1) %>%
       summarise(mean.dur = mean(duration.time, na.rm = TRUE),
                 median.dur = median(duration.time, na.rm = TRUE)) %>%
       as.data.frame()
@@ -944,11 +944,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$md.inst <- as.numeric(pred)
   } else {
-    mod <- glm(count.oo.part ~ geog,
+    mod <- glm(count.oo.part ~ geogYN,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")/(364/time.unit)
 
     out$inst$md.inst <- as.numeric(pred)
@@ -975,11 +975,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$nm.age.grp <- as.numeric(pred)
   } else {
-    mod <- glm(same.age.grp ~ geog + index.age.grp,
+    mod <- glm(same.age.grp ~ geogYN + index.age.grp,
                data = linst, family = binomial())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, index.age.grp = 1:age.grps)
+    dat <- data.frame(geogYN = 1, index.age.grp = 1:age.grps)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$inst$nm.age.grp <- as.numeric(pred)
@@ -999,10 +999,10 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$absdiff.age <- as.numeric(pred)
   } else {
-    mod <- lm(ad ~ geog, data = linst)
+    mod <- lm(ad ~ geogYN, data = linst)
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$inst$absdiff.age <- as.numeric(pred)
@@ -1019,10 +1019,10 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$absdiff.sqrt.age <- as.numeric(pred)
   } else {
-    mod <- lm(ad.sr ~ geog, data = linst)
+    mod <- lm(ad.sr ~ geogYN, data = linst)
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat)
+    dat <- data.frame(geogYN = 1)
     pred <- predict(mod, newdata = dat, type = "response")
 
     out$inst$absdiff.sqrt.age <- as.numeric(pred)
@@ -1044,11 +1044,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$nf.age.grp <- as.numeric(pred)
   } else {
-    mod <- glm(count.oo.part ~ geog + age.grp + sqrt(age.grp),
+    mod <- glm(count.oo.part ~ geogYN + age.grp + sqrt(age.grp),
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, age.grp = 1:age.grps)
+    dat <- data.frame(geogYN = 1, age.grp = 1:age.grps)
     pred <- predict(mod, newdata = dat, type = "response")/(364/time.unit)
 
     out$inst$nf.age.grp <- as.numeric(pred)
@@ -1073,11 +1073,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$inst$nm.race <- as.numeric(pred)
     } else {
-      mod <- glm(same.race ~ geog + as.factor(race.cat3),
+      mod <- glm(same.race ~ geogYN + as.factor(race.cat3),
                  data = linst, family = binomial())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat, race.cat3 = 1:3)
+      dat <- data.frame(geogYN = 1, race.cat3 = 1:3)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$inst$nm.race <- as.numeric(pred)
@@ -1095,11 +1095,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$inst$nm.race_diffF <- as.numeric(pred)
     } else {
-      mod <- glm(same.race ~ geog,
+      mod <- glm(same.race ~ geogYN,
                  data = linst, family = binomial())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat)
+      dat <- data.frame(geogYN = 1)
       pred <- predict(mod, newdata = dat, type = "response")
 
       out$inst$nm.race_diffF <- as.numeric(pred)
@@ -1119,11 +1119,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
       out$inst$nf.race <- as.numeric(pred)
     } else {
-      mod <- glm(count.oo.part ~ geog + as.factor(race.cat3),
+      mod <- glm(count.oo.part ~ geogYN + as.factor(race.cat3),
                  data = d, family = poisson())
       # summary(mod)
 
-      dat <- data.frame(geog = geog.cat, race.cat3 = 1:3)
+      dat <- data.frame(geogYN = 1, race.cat3 = 1:3)
       pred <- predict(mod, newdata = dat, type = "response")/(364/time.unit)
 
       out$inst$nf.race <- as.numeric(pred)
@@ -1135,7 +1135,7 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
   # geography-specific wts
 
   if (!is.null(geog.lvl)) {
-    wt <- mean(d$rate.oo.part[d$geog == geog.cat],
+    wt <- mean(d$rate.oo.part[d$geogYN == 1],
                na.rm = TRUE)/mean(d$rate.oo.part, na.rm = TRUE)
   } else {
     wt <- 1
@@ -1177,7 +1177,7 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
   d$deg.tot3 <- ifelse(d$deg.tot >= 3, 3, d$deg.tot)
 
   if (!is.null(geog.lvl)) {
-    deg.tot.dist <- prop.table(table(d$deg.tot3[d$geog == geog.cat]))
+    deg.tot.dist <- prop.table(table(d$deg.tot3[d$geogYN == 1]))
     out$inst$deg.tot.dist <- as.numeric(deg.tot.dist)
   } else {
     deg.tot.dist <- prop.table(table(d$deg.tot3))
@@ -1194,11 +1194,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$nf.deg.tot <- as.numeric(pred)
   } else {
-    mod <- glm(count.oo.part ~ geog + deg.tot3 + sqrt(deg.tot3),
+    mod <- glm(count.oo.part ~ geogYN + deg.tot3 + sqrt(deg.tot3),
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, deg.tot3 = 0:3)
+    dat <- data.frame(geogYN = 1, deg.tot3 = 0:3)
     pred <- predict(mod, newdata = dat, type = "response")/(364/time.unit)
 
     out$inst$nf.deg.tot <- as.numeric(pred)
@@ -1217,11 +1217,11 @@ build_netparams <- function(epistats, smooth.main.dur = FALSE) {
 
     out$inst$nf.diag.status <- as.numeric(pred)
   } else {
-    mod <- glm(count.oo.part ~ geog + hiv2,
+    mod <- glm(count.oo.part ~ geogYN + hiv2,
                data = d, family = poisson())
     # summary(mod)
 
-    dat <- data.frame(geog = geog.cat, hiv2 = 0:1)
+    dat <- data.frame(geogYN = 1, hiv2 = 0:1)
     pred <- predict(mod, newdata = dat, type = "response")/(364/time.unit)
 
     out$inst$nf.diag.status <- as.numeric(pred)

--- a/R/NetStats.R
+++ b/R/NetStats.R
@@ -12,6 +12,12 @@
 #'        \code{\link{dissolution_coefs}} function.
 #' @param edges.avg Whether degree differences exist along race. TRUE
 #'        or FALSE; default of FALSE.
+#' @param race.prop The proportion of the population with each of the three
+#'        values for the nodal attribute "race" (White.Other, Black, Hispanic).
+#'        This only needs to be supplied if geog.lvl = "county" or if geog.cat
+#'        has length >1; otherwise, the values can be obtained automatically
+#'        from a look-up table. If it is not supplied in either of these cases,
+#'        the function will default to national US values.
 #'
 #' @details
 #' \code{build_netstats} takes output from \code{\link{build_epistats}} and

--- a/R/NetStats.R
+++ b/R/NetStats.R
@@ -34,7 +34,8 @@
 build_netstats <- function(epistats, netparams,
                            network.size = 10000,
                            expect.mort = 0.0001,
-                           edges.avg = FALSE) {
+                           edges.avg = FALSE,
+                           race.prop = NULL) {
 
   ## Data ##
   #NOTE: Not actually used
@@ -64,10 +65,15 @@ build_netstats <- function(epistats, netparams,
   # Population size by race group
   # race.dist.3cat
 
-  if (!is.null(geog.lvl)) {
-  props <- race.dist[[geog.lvl]][which(race.dist[[geog.lvl]]$Geog == geog.cat), -c(1,2)]/100
+  if (!is.null(race.prop)) {
+    props <- as.data.frame(t(race.prop))
+    colnames(props) <- c('White.Other','Black','Hispanic')
   } else {
-    props <- race.dist[["national"]][, -c(1,2)]/100
+    if (!is.null(geog.lvl)) {
+      props <- race.dist[[geog.lvl]][which(race.dist[[geog.lvl]]$Geog == geog.cat), -c(1,2)]/100
+    } else {
+      props <- race.dist[["national"]][, -c(1,2)]/100
+    }
   }
   num.B <- out$demog$num.B <- round(num * props$Black)
   num.H <- out$demog$num.H <- round(num * props$Hispanic)

--- a/R/NetStats.R
+++ b/R/NetStats.R
@@ -69,8 +69,9 @@ build_netstats <- function(epistats, netparams,
     props <- as.data.frame(t(race.prop))
     colnames(props) <- c('White.Other','Black','Hispanic')
   } else {
-    if (!is.null(geog.lvl)) {
-      props <- race.dist[[geog.lvl]][which(race.dist[[geog.lvl]]$Geog == geog.cat), -c(1,2)]/100
+    if (!is.null(geog.lvl) & geog.lvl !="county" & length(geog.cat)==1) {
+      props <- race.dist[[geog.lvl]][which(race.dist[[geog.lvl]]$Geog == geog.cat),
+                                     -c(1,2)]/100
     } else {
       props <- race.dist[["national"]][, -c(1,2)]/100
     }

--- a/man/build_epistats.Rd
+++ b/man/build_epistats.Rd
@@ -45,7 +45,7 @@ Use 1 for daily time units and 30 for monthly time units.}
 }
 \description{
 Builds statistical models governing act rates and probability of
-             condom use among main, casual and one-of sexual partnerships, and
+             condom use among main, casual and one-time sexual partnerships, and
              the probability of diagnosed HIV infection, for use in the EpiModelHIV
              workflow.
 }
@@ -76,7 +76,11 @@ values for each input parameter are provided below.
            \code{"Los Angeles"}, \code{"Miami"}, \code{"New York City"},
            \code{"Philadelphia"}, \code{"San Diego"}, \code{"San Franciso"},
            \code{"Seattle"}, \code{"Washington DC"}
-     \item \code{county}: FIPS codes for the county or county equivalents to be included.
+     \item \code{county}: FIPS codes for the county or county equivalents to
+     be included. Be aware that selecting a single county or a set of smaller
+     counties may lead to insufficient data being used to estimate the model;
+     if the sample lacks sufficient behavioral diversity (e.g. if nobody
+     reports 2+ ongoing casual partners), an error may result.
      \item \code{state}: \code{"AK"}, \code{"AL"}, \code{"AR"}, \code{"AZ"},
            \code{"CA"}, \code{"CO"}, \code{"CT"}, \code{"DC"}, \code{"DE"},
            \code{"FL"}, \code{"GA"}, \code{"HI"}, \code{"IA"}, \code{"ID"},

--- a/man/build_netstats.Rd
+++ b/man/build_netstats.Rd
@@ -9,7 +9,8 @@ build_netstats(
   netparams,
   network.size = 10000,
   expect.mort = 1e-04,
-  edges.avg = FALSE
+  edges.avg = FALSE,
+  race.prop = NULL
 )
 }
 \arguments{

--- a/man/build_netstats.Rd
+++ b/man/build_netstats.Rd
@@ -25,6 +25,13 @@ build_netstats(
 
 \item{edges.avg}{Whether degree differences exist along race. TRUE
 or FALSE; default of FALSE.}
+
+\item{race.prop}{The proportion of the population with each of the three
+values for the nodal attribute "race" (White.Other, Black, Hispanic).
+This only needs to be supplied if geog.lvl = "county" or if geog.cat
+has length >1; otherwise, the values can be obtained automatically
+from a look-up table. If it is not supplied in either of these cases,
+the function will default to national US values.}
 }
 \description{
 Calculates the final target statistics for the network models by


### PR DESCRIPTION
- In `build_epistats`, replaces regressions based on `geog` with those based on `geogYN`, thus allowing for multiple jurisdictions to be included. 
- In `build_netstats`, provides option for passing in `race.prop`, avoiding the need for us to generate a look-up table for every county.
Closes #39 
Closes #40