### PR TITLE
Simplify edge dissolution handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: knitr
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Encoding: UTF-8
 Remotes:
    github::EpiModel/ARTnetData@main,

--- a/R/NetParams.R
+++ b/R/NetParams.R
@@ -7,8 +7,6 @@
 #' @param epistats Output from [`build_epistats`].
 #' @param smooth.main.dur If `TRUE`, function averages the main sexual partnership durations for
 #'        oldest and second oldest age groups.
-#' @param cessation.dissolve.edges If `TRUE`, immediate dissolution model parameters added for the
-#'        oldest age group representing persons after sexual cessation.
 #' @param oo.nquants Number of quantiles to split the one-off partnership risk distribution (count
 #'        of one-off partners per unit time).
 #' @param browser If `TRUE`, run `build_netparams` in interactive browser mode.
@@ -24,12 +22,6 @@
 #' done if there are three or more age categories specified. Note, this does not affect calculations
 #' if an age group after sexual cessation is included; durations averaged only in the oldest two
 #' age groups within the bounds of the sexual cessation age.
-#'
-#' If the parameter `cessation.dissolve.edges` is `TRUE`, this assumes that all existing partnerships
-#' will dissolve between anyone over the upper boundary of the age of sexual cessation. If `FALSE`,
-#' no new partnerships will occur within this age group, but existing partnerships are allowed to
-#' continue through their natural dissolution. This parameter is ignored if there is no upper age
-#' group of sexually inactive persons.
 #'
 #' @export
 #' @examples
@@ -52,13 +44,8 @@
 #'                             age.sexual.cessation = 65)
 #' netparams3 <- build_netparams(epistats3, smooth.main.dur = TRUE)
 #'
-#' # Alternative with cessation not dissolving edges (note duration table)
-#' netparams4 <- build_netparams(epistats3, smooth.main.dur = TRUE,
-#'                               cessation.dissolve.edges = FALSE)
-#'
 build_netparams <- function(epistats,
                             smooth.main.dur = FALSE,
-                            cessation.dissolve.edges = TRUE,
                             oo.nquants = 5,
                             browser = FALSE) {
 

--- a/R/NetParams.R
+++ b/R/NetParams.R
@@ -514,16 +514,11 @@ build_netparams <- function(epistats,
     }
   }
 
-  # if dissolve edges, then setting dissolution rates for highest age group to 1
+  # If sexual cessation model, then set diss coef for age grp above boundary to 1
   if (sex.cess.mod == TRUE) {
     index.age.grp <- max(out$main$durs.main.byage$index.age.grp) + 1
-    if (cessation.dissolve.edges == TRUE) {
-      df <- data.frame(index.age.grp = index.age.grp, mean.dur = 1, median.dur = 1,
-                       rates.main.adj = 1, mean.dur.adj = 1)
-    } else {
-      df <- tail(out$main$durs.main.byage, 1)
-      df$index.age.grp <- index.age.grp
-    }
+    df <- data.frame(index.age.grp = index.age.grp, mean.dur = 1, median.dur = 1,
+                     rates.main.adj = 1, mean.dur.adj = 1)
     out$main$durs.main.byage <- rbind(out$main$durs.main.byage, df)
   }
 
@@ -840,16 +835,11 @@ build_netparams <- function(epistats,
   durs.casl.all <- durs.casl.all[, c(3, 1, 2, 4, 5)]
   out$casl$durs.casl.byage <- durs.casl.all
 
-  # if dissolve edges, then setting dissolution rates for highest age group to 0
+  # If sexual cessation model, then set diss coef for age grp above boundary to 1
   if (sex.cess.mod == TRUE) {
     index.age.grp <- max(out$casl$durs.casl.byage$index.age.grp) + 1
-    if (cessation.dissolve.edges == TRUE) {
-      df <- data.frame(index.age.grp = index.age.grp, mean.dur = 1, median.dur = 1,
-                       rates.casl.adj = 1, mean.dur.adj = 1)
-    } else {
-      df <- tail(out$casl$durs.casl.byage, 1)
-      df$index.age.grp <- index.age.grp
-    }
+    df <- data.frame(index.age.grp = index.age.grp, mean.dur = 1, median.dur = 1,
+                     rates.casl.adj = 1, mean.dur.adj = 1)
     out$casl$durs.casl.byage <- rbind(out$casl$durs.casl.byage, df)
   }
 

--- a/man/build_netparams.Rd
+++ b/man/build_netparams.Rd
@@ -7,7 +7,6 @@
 build_netparams(
   epistats,
   smooth.main.dur = FALSE,
-  cessation.dissolve.edges = TRUE,
   oo.nquants = 5,
   browser = FALSE
 )
@@ -17,9 +16,6 @@ build_netparams(
 
 \item{smooth.main.dur}{If \code{TRUE}, function averages the main sexual partnership durations for
 oldest and second oldest age groups.}
-
-\item{cessation.dissolve.edges}{If \code{TRUE}, immediate dissolution model parameters added for the
-oldest age group representing persons after sexual cessation.}
 
 \item{oo.nquants}{Number of quantiles to split the one-off partnership risk distribution (count
 of one-off partners per unit time).}
@@ -41,12 +37,6 @@ groups (as specified by \code{age.breaks} in \code{\link{build_epistats}}). Subs
 done if there are three or more age categories specified. Note, this does not affect calculations
 if an age group after sexual cessation is included; durations averaged only in the oldest two
 age groups within the bounds of the sexual cessation age.
-
-If the parameter \code{cessation.dissolve.edges} is \code{TRUE}, this assumes that all existing partnerships
-will dissolve between anyone over the upper boundary of the age of sexual cessation. If \code{FALSE},
-no new partnerships will occur within this age group, but existing partnerships are allowed to
-continue through their natural dissolution. This parameter is ignored if there is no upper age
-group of sexually inactive persons.
 }
 \examples{
 # Standard model with default age stratification
@@ -67,9 +57,5 @@ epistats3 <- build_epistats(geog.lvl = "city",
                             age.breaks = c(25, 35, 45, 55),
                             age.sexual.cessation = 65)
 netparams3 <- build_netparams(epistats3, smooth.main.dur = TRUE)
-
-# Alternative with cessation not dissolving edges (note duration table)
-netparams4 <- build_netparams(epistats3, smooth.main.dur = TRUE,
-                              cessation.dissolve.edges = FALSE)
 
 }

--- a/tests/testthat/test-workflow-cea.R
+++ b/tests/testthat/test-workflow-cea.R
@@ -1,7 +1,9 @@
 
 ## testing ARTnet workflow on full-scale MSM model with max age 65
 
-## should work on EpiModelHIV-p@main
+## Script must work on EpiModelHIV-p@main and CRAN versions of all packages
+## install.packages(c("statnet.common", "ergm", "tergm", "network", "networkDynamic",
+##                    "EpiModel", "ergm.ego", "egor", "ergm.multi"))
 
 # Setup  -----------------------------------------------------------------------
 library("EpiModelHIV")
@@ -22,7 +24,6 @@ epistats <- build_epistats(
 netparams <- build_netparams(
   epistats = epistats,
   smooth.main.dur = TRUE,
-  cessation.dissolve.edges = TRUE
 )
 
 netstats <- build_netstats(
@@ -36,6 +37,8 @@ netstats <- build_netstats(
 table(floor(netstats$attr$age))
 sum(netstats$attr$age >= 65)
 hist(netstats$attr$age)
+
+table(netstats$attr$age.grp)
 
 netstats$main$nodefactor_age.grp
 sum(netstats$main$nodefactor_age.grp) / 2
@@ -95,6 +98,7 @@ fit_main <- netest(
   verbose = FALSE
 )
 fit_main <- trim_netest(fit_main)
+
 
 # 2. Casual Model ---------------------------------------------------------
 

--- a/tests/testthat/test-workflow-standard.R
+++ b/tests/testthat/test-workflow-standard.R
@@ -196,7 +196,7 @@ dx_main <- netdx(
   fit_main,
   nsims = nsims,
   ncores = ncores,
-  nsteps = nsteps * 2,
+  nsteps = nsteps,
   nwstats.formula = model_main_dx,
   set.control.ergm = control.simulate.formula(MCMC.burnin = 1e5),
   set.control.tergm = control.simulate.formula.tergm(MCMC.burnin.min = 2e5)


### PR DESCRIPTION
Simplifies the `cessation.dissolve.edges` argument from `build_epistats` as this is now handled in `EpiModelHIV` itself. Still need a coefficient passed for the age group above the cessation threshold, so that gets set to 1 in all cases now.