### PR TITLE
Speed up `make_race_combo`

### DIFF
--- a/R/EpiStats.R
+++ b/R/EpiStats.R
@@ -574,7 +574,8 @@ build_epistats <- function(geog.lvl = NULL,
 #' @export
 #'
 make_race_combo <- function(race1, race2) {
-  race_combo <- ifelse(race1 == race2, 2 * race1 - 1, 2 * race1)
+  race_combo <- 2 * race1
+  race_combo[race1 == race2] <- race_combo[race1 == race2] - 1
   return(race_combo)
 }
 
@@ -614,4 +615,3 @@ trim_epistats <- function(epistats) {
   epistats$cond.oo.mod <- strip_glm(epistats$cond.oo.mod)
   return(epistats)
 }
-


### PR DESCRIPTION
Twice as fast and half the memory usage:

For 100k nodes and 3 race levels in the condoms modules:

```
Unit: microseconds
   expr      min       lq      mean   median       uq      max neval
 ifelse 1464.726 1541.845 2081.0892 1578.244 1733.035 4833.122   100
    sub  756.592  774.961  917.6406  784.161  805.682 3674.941   100

# A tibble: 2 × 13
  expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
  <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
1 ifelse       1.47ms   1.56ms      625.    4.91MB    113.    171    31
2 sub        761.65µs 787.83µs     1236.    2.37MB     85.5   448    31
# ℹ 5 more variables: total_time <bch:tm>, result <list>, memory <list>,
#   time <list>, gc <list>
```