### PR TITLE
Use joint GLM g-computation for build_netstats target stats (#62)

### DIFF
--- a/R/NetParams.R
+++ b/R/NetParams.R
@@ -1,11 +1,14 @@
-# Fit a joint Poisson GLM predicting `response` from all available
-# individual attributes (age, race, the concurrent-layer degree, HIV
-# status, geography). Candidate interactions are considered one at a
-# time and kept only when they reduce AIC. Internal helper for the
-# `method = "joint"` path of `build_netparams()`; see issue #61.
-fit_joint_poisson <- function(d, response, main_terms,
-                              race, geog.lvl,
-                              interaction_cross_deg = NULL) {
+# Fit a joint GLM predicting `response` from all available individual
+# attributes (age, race, the concurrent-layer degree, HIV status,
+# geography). Candidate interactions are considered one at a time and
+# kept only when they reduce AIC. `family` selects between the Poisson
+# model for degree / one-off count and the binomial model for the
+# concurrency indicator (1 = deg > 1). Internal helper for the
+# `method = "joint"` path of `build_netparams()`; see issues #61 / #62.
+fit_joint_glm <- function(d, response, main_terms,
+                          race, geog.lvl,
+                          interaction_cross_deg = NULL,
+                          family = poisson()) {
   if (isTRUE(race)) {
     main_terms <- c(main_terms, "as.factor(race.cat.num)")
   }
@@ -14,7 +17,7 @@ fit_joint_poisson <- function(d, response, main_terms,
   }
 
   base_fml <- reformulate(main_terms, response = response)
-  best <- glm(base_fml, data = d, family = poisson())
+  best <- glm(base_fml, data = d, family = family)
   selected <- character(0)
 
   candidates <- character(0)
@@ -28,7 +31,7 @@ fit_joint_poisson <- function(d, response, main_terms,
   for (ix in candidates) {
     ix_fml <- update(formula(best), paste("~ . +", ix))
     cand <- tryCatch(
-      suppressWarnings(glm(ix_fml, data = d, family = poisson())),
+      suppressWarnings(glm(ix_fml, data = d, family = family)),
       error = function(e) NULL
     )
     if (!is.null(cand) && isTRUE(cand$converged) && AIC(cand) < AIC(best)) {
@@ -56,11 +59,12 @@ fit_joint_poisson <- function(d, response, main_terms,
 #' @param method Character. Either `"existing"` (default) or `"joint"`. `"existing"` reproduces
 #'        the pre-refactor behavior byte-for-byte: a separate univariate Poisson/binomial GLM is
 #'        fit for each ERGM target statistic. `"joint"` leaves all of those outputs intact **and**
-#'        additionally fits one joint Poisson GLM per layer (main/casual/one-off) predicting
-#'        degree (or one-off partner count) from all attributes simultaneously, with AIC-based
-#'        interaction selection. The fitted objects are returned at `$main$joint_model`,
-#'        `$casl$joint_model`, and `$inst$joint_model` and form the basis of the g-computation
-#'        refactor planned for [`build_netstats`] in a later release.
+#'        additionally fits joint GLMs per layer with AIC-based interaction selection:
+#'        a Poisson model for degree (main/casual) or one-off partner count (inst), stored at
+#'        `$<layer>$joint_model`; and, for the main and casual layers, a binomial model for the
+#'        concurrency indicator (`deg > 1`), stored at `$<layer>$joint_concurrent_model`. These
+#'        models are consumed by [`build_netstats`] under `method = "joint"` to produce
+#'        internally-consistent g-computation target statistics.
 #' @param browser If `TRUE`, run `build_netparams` in interactive browser mode.
 #'
 #' @details
@@ -598,15 +602,25 @@ build_netparams <- function(epistats,
   }
 
 
-  ## joint g-computation model (additive output; see issue #61) ----
+  ## joint g-computation models (additive outputs; see issues #61/#62) ----
   if (method == "joint") {
-    out$main$joint_model <- fit_joint_poisson(
+    out$main$joint_model <- fit_joint_glm(
       d,
       response = "deg.main",
       main_terms = c("age.grp", "sqrt(age.grp)", "deg.casl", "hiv2"),
       race = race,
       geog.lvl = geog.lvl,
-      interaction_cross_deg = "deg.casl"
+      interaction_cross_deg = "deg.casl",
+      family = poisson()
+    )
+    out$main$joint_concurrent_model <- fit_joint_glm(
+      d,
+      response = "deg.main.conc",
+      main_terms = c("age.grp", "sqrt(age.grp)", "deg.casl", "hiv2"),
+      race = race,
+      geog.lvl = geog.lvl,
+      interaction_cross_deg = "deg.casl",
+      family = binomial()
     )
   }
 
@@ -933,15 +947,25 @@ build_netparams <- function(epistats,
   }
 
 
-  ## joint g-computation model (additive output; see issue #61) ----
+  ## joint g-computation models (additive outputs; see issues #61/#62) ----
   if (method == "joint") {
-    out$casl$joint_model <- fit_joint_poisson(
+    out$casl$joint_model <- fit_joint_glm(
       d,
       response = "deg.casl",
       main_terms = c("age.grp", "sqrt(age.grp)", "deg.main", "hiv2"),
       race = race,
       geog.lvl = geog.lvl,
-      interaction_cross_deg = "deg.main"
+      interaction_cross_deg = "deg.main",
+      family = poisson()
+    )
+    out$casl$joint_concurrent_model <- fit_joint_glm(
+      d,
+      response = "deg.casl.conc",
+      main_terms = c("age.grp", "sqrt(age.grp)", "deg.main", "hiv2"),
+      race = race,
+      geog.lvl = geog.lvl,
+      interaction_cross_deg = "deg.main",
+      family = binomial()
     )
   }
 
@@ -1216,15 +1240,17 @@ build_netparams <- function(epistats,
 
 
   ## joint g-computation model (additive output; see issue #61) ----
+  # No concurrent target for the one-off layer, so no binomial model here.
   if (method == "joint") {
-    out$inst$joint_model <- fit_joint_poisson(
+    out$inst$joint_model <- fit_joint_glm(
       d,
       response = "count.oo.part",
       main_terms = c("age.grp", "sqrt(age.grp)", "deg.tot3", "sqrt(deg.tot3)",
                      "hiv2"),
       race = race,
       geog.lvl = geog.lvl,
-      interaction_cross_deg = "deg.tot3"
+      interaction_cross_deg = "deg.tot3",
+      family = poisson()
     )
   }
 

--- a/R/NetStats.R
+++ b/R/NetStats.R
@@ -20,6 +20,20 @@
 #' @param young.prop The proportion of the population that should be below the age of sexual cessation.
 #'        Default is NULL (meaning no re-weighting of the `age.pyramid` parameter is performed).
 #'        This parameter is only used if the age of sexual cessation is less than the upper age bound.
+#' @param method Character. Either `"existing"` (default) or `"joint"`. `"existing"` reproduces
+#'        the pre-refactor behavior byte-for-byte: target statistics for edges, nodefactor, and
+#'        concurrent are computed layer-by-layer from the univariate marginal fits stored on
+#'        `netparams`. `"joint"` uses the joint Poisson GLM fit at `netparams$<layer>$joint_model`
+#'        (set by `build_netparams(..., method = "joint")`) to predict expected degree for each
+#'        synthetic-population node and aggregates via g-computation:
+#'        `edges = sum(pred) / 2` and `nodefactor_<attr>[level] = sum(pred[attr == level])`.
+#'        Under `"joint"`, edges and all nodefactor target stats are internally consistent by
+#'        construction (`sum(nodefactor_<attr>) = 2 * edges`), so `edges.avg` has no effect.
+#'        `nodematch_*`, `absdiff_*`, dissolution coefficients, `concurrent`, and
+#'        `nodefactor_risk.grp` continue to use the univariate marginals — those are scoped for
+#'        later issues (#63–#64). `concurrent` in particular is retained from the univariate
+#'        binomial fit because the joint Poisson's implied `P(deg > 1)` is biased by the
+#'        truncation of `deg.main` and `deg.casl` in the training data.
 #' @param browser If `TRUE`, run `build_netparams` in interactive browser mode.
 #'
 #' @details
@@ -82,9 +96,24 @@ build_netstats <- function(epistats, netparams,
                            edges.avg = FALSE,
                            race.prop = NULL,
                            young.prop = NULL,
+                           method = c("existing", "joint"),
                            browser = FALSE) {
+  method <- match.arg(method)
+
   # Ensures that ARTnetData is installed
   if (system.file(package = "ARTnetData") == "") stop(missing_data_msg)
+
+  if (method == "joint") {
+    missing_joint <- vapply(c("main", "casl", "inst"),
+      function(layer) is.null(netparams[[layer]]$joint_model),
+      logical(1))
+    if (any(missing_joint)) {
+      stop("method = 'joint' requires netparams fit with method = 'joint'. ",
+           "No joint_model on layer(s): ",
+           paste(names(missing_joint)[missing_joint], collapse = ", "), ". ",
+           "Re-run build_netparams(..., method = 'joint').")
+    }
+  }
 
   if (browser == TRUE) {
     browser()
@@ -370,62 +399,143 @@ build_netstats <- function(epistats, netparams,
   out$attr$diag.status <- as.integer(out$attr$diag.status)
 
 
+  # Joint g-computation predictions (method = "joint" only) -----------------
+  # Predict per-synthetic-node expected degree from the joint Poisson GLMs
+  # fit in build_netparams(..., method = "joint"). Aggregating these per-node
+  # predictions gives target statistics that are internally consistent by
+  # construction (sum(nodefactor_<attr>) == 2 * edges). Inactive-age nodes
+  # (sex.cess.mod) are zeroed out so they contribute nothing to any layer's
+  # edges or nodefactor counts.
+  if (method == "joint") {
+    synth <- data.frame(
+      age.grp      = out$attr$age.grp,
+      race.cat.num = out$attr$race,
+      deg.main     = out$attr$deg.main,
+      deg.casl     = out$attr$deg.casl,
+      hiv2         = out$attr$diag.status,
+      geogYN       = 1L
+    )
+    synth$deg.tot3 <- pmin(out$attr$deg.tot, 3)
+
+    pred_deg_main   <- predict(netparams$main$joint_model, newdata = synth, type = "response")
+    pred_deg_casl   <- predict(netparams$casl$joint_model, newdata = synth, type = "response")
+    pred_count_inst <- predict(netparams$inst$joint_model, newdata = synth, type = "response")
+    pred_deg_inst   <- pred_count_inst / (364 / time.unit)
+
+    if (sex.cess.mod == TRUE) {
+      inactive <- out$attr$active.sex == 0L
+      pred_deg_main[inactive] <- 0
+      pred_deg_casl[inactive] <- 0
+      pred_deg_inst[inactive] <- 0
+    }
+  }
+
+
   # Main Model -----------------------------------------------------------
 
   out$main <- list()
 
-  # edges ---
-  if (race == TRUE) {
-    if (edges.avg == FALSE) {
-      out$main$edges <- (netparams$main$md.main * num) / 2
+  if (method == "existing") {
+
+    # edges ---
+    if (race == TRUE) {
+      if (edges.avg == FALSE) {
+        out$main$edges <- (netparams$main$md.main * num) / 2
+      } else {
+        out$main$edges <- sum(unname(table(out$attr$race)) * netparams$main$nf.race) / 2
+      }
+      # nodefactor("race") ---
+      nodefactor_race <- table(out$attr$race) * netparams$main$nf.race
+      out$main$nodefactor_race <- unname(nodefactor_race)
+
+      # nodematch("race") ---
+      nodematch_race <- nodefactor_race / 2 * netparams$main$nm.race
+      out$main$nodematch_race <- unname(nodematch_race)
+
+      # nodematch("race", diff = FALSE) ---
+      nodematch_race <- out$main$edges * netparams$main$nm.race_diffF
+      out$main$nodematch_race_diffF <- unname(nodematch_race)
     } else {
-      out$main$edges <- sum(unname(table(out$attr$race)) * netparams$main$nf.race) / 2
+      out$main$edges <- (netparams$main$md.main * num) / 2
     }
-    # nodefactor("race") ---
-    nodefactor_race <- table(out$attr$race) * netparams$main$nf.race
-    out$main$nodefactor_race <- unname(nodefactor_race)
 
-    # nodematch("race") ---
-    nodematch_race <- nodefactor_race / 2 * netparams$main$nm.race
-    out$main$nodematch_race <- unname(nodematch_race)
+    # nodefactor("age.grp") ---
+    nodefactor_age.grp <- table(out$attr$age.grp) * netparams$main$nf.age.grp
+    if (sex.cess.mod == TRUE) {
+      nodefactor_age.grp[length(nodefactor_age.grp)] <- 0
+    }
+    out$main$nodefactor_age.grp <- unname(nodefactor_age.grp)
 
-    # nodematch("race", diff = FALSE) ---
-    nodematch_race <- out$main$edges * netparams$main$nm.race_diffF
-    out$main$nodematch_race_diffF <- unname(nodematch_race)
-  } else {
-    out$main$edges <- (netparams$main$md.main * num) / 2
+    # nodematch("age.grp") ---
+    nodematch_age.grp <- nodefactor_age.grp / 2 * netparams$main$nm.age.grp
+    out$main$nodematch_age.grp <- unname(nodematch_age.grp)
+
+    # absdiff("age") ---
+    absdiff_age <- out$main$edges * netparams$main$absdiff.age
+    out$main$absdiff_age <- absdiff_age
+
+    # absdiff("sqrt.age") ---
+    absdiff_sqrt.age <- out$main$edges * netparams$main$absdiff.sqrt.age
+    out$main$absdiff_sqrt.age <- absdiff_sqrt.age
+
+    # nodefactor("deg.casl") ---
+    out$main$nodefactor_deg.casl <- num * netparams$main$deg.casl.dist * netparams$main$nf.deg.casl
+
+    # concurrent ---
+    out$main$concurrent <- num * netparams$main$concurrent
+
+    # nodefactor("diag.status") ---
+    nodefactor_diag.status <- table(out$attr$diag.status) * netparams$main$nf.diag.status
+    out$main$nodefactor_diag.status <- unname(nodefactor_diag.status)
+
+  } else {  # method == "joint"
+
+    # edges from summed per-node predictions --------------------------------
+    out$main$edges <- sum(pred_deg_main) / 2
+
+    # nodefactor + derived nodematch terms ----------------------------------
+    if (race == TRUE) {
+      n_race <- length(netparams$main$nf.race)
+      out$main$nodefactor_race <- vapply(seq_len(n_race),
+        function(r) sum(pred_deg_main[out$attr$race == r]), numeric(1))
+      out$main$nodematch_race <- unname(
+        out$main$nodefactor_race / 2 * netparams$main$nm.race)
+      out$main$nodematch_race_diffF <- unname(
+        out$main$edges * netparams$main$nm.race_diffF)
+    }
+
+    # nodefactor("age.grp") -------------------------------------------------
+    n_age <- length(netparams$main$nf.age.grp)
+    out$main$nodefactor_age.grp <- vapply(seq_len(n_age),
+      function(k) sum(pred_deg_main[out$attr$age.grp == k]), numeric(1))
+
+    # nodematch("age.grp") -- reuse univariate nm ratio on new nodefactor
+    out$main$nodematch_age.grp <- unname(
+      out$main$nodefactor_age.grp / 2 * netparams$main$nm.age.grp)
+
+    # absdiff stats scale with new edges ------------------------------------
+    out$main$absdiff_age <- out$main$edges * netparams$main$absdiff.age
+    out$main$absdiff_sqrt.age <- out$main$edges * netparams$main$absdiff.sqrt.age
+
+    # nodefactor("deg.casl") ------------------------------------------------
+    out$main$nodefactor_deg.casl <- vapply(0:3,
+      function(d) sum(pred_deg_main[out$attr$deg.casl == d]), numeric(1))
+
+    # concurrent -- keep the univariate binomial unchanged. The Poisson
+    # joint model's implied P(deg > 1) = 1 - exp(-lambda)(1+lambda) would
+    # inflate this ~5x because deg.main is truncated at 2 in the training
+    # data, so the fitted lambda approximates E[min(deg, 2)] rather than
+    # the true Poisson rate. The binomial logistic fit is the right model
+    # for the probability of concurrency; joint-modeling it is scoped to
+    # a separate issue.
+    out$main$concurrent <- num * netparams$main$concurrent
+
+    # nodefactor("diag.status") ---------------------------------------------
+    out$main$nodefactor_diag.status <- vapply(0:1,
+      function(h) sum(pred_deg_main[out$attr$diag.status == h]), numeric(1))
   }
 
-  # nodefactor("age.grp") ---
-  nodefactor_age.grp <- table(out$attr$age.grp) * netparams$main$nf.age.grp
-  if (sex.cess.mod == TRUE) {
-    nodefactor_age.grp[length(nodefactor_age.grp)] <- 0
-  }
-  out$main$nodefactor_age.grp <- unname(nodefactor_age.grp)
-
-  # nodematch("age.grp") ---
-  nodematch_age.grp <- nodefactor_age.grp / 2 * netparams$main$nm.age.grp
-  out$main$nodematch_age.grp <- unname(nodematch_age.grp)
-
-  # absdiff("age") ---
-  absdiff_age <- out$main$edges * netparams$main$absdiff.age
-  out$main$absdiff_age <- absdiff_age
-
-  # absdiff("sqrt.age") ---
-  absdiff_sqrt.age <- out$main$edges * netparams$main$absdiff.sqrt.age
-  out$main$absdiff_sqrt.age <- absdiff_sqrt.age
-
-  # nodefactor("deg.casl") ---
-  out$main$nodefactor_deg.casl <- num * netparams$main$deg.casl.dist * netparams$main$nf.deg.casl
-
-  # concurrent ---
-  out$main$concurrent <- num * netparams$main$concurrent
-
-  # nodefactor("diag.status") ---
-  nodefactor_diag.status <- table(out$attr$diag.status) * netparams$main$nf.diag.status
-  out$main$nodefactor_diag.status <- unname(nodefactor_diag.status)
-
-  # Dissolution ---
+  # Dissolution (identical under both methods) -----------------------------
   out$main$diss.homog <- dissolution_coefs(dissolution = ~offset(edges),
                                            duration = netparams$main$durs.main.homog$mean.dur.adj,
                                            d.rate = expect.mort)
@@ -440,58 +550,97 @@ build_netstats <- function(epistats, netparams,
 
   out$casl <- list()
 
-  # edges ---
-  if (race == TRUE) {
-    if (edges.avg == FALSE) {
-      out$casl$edges <- (netparams$casl$md.casl * num) / 2
+  if (method == "existing") {
+
+    # edges ---
+    if (race == TRUE) {
+      if (edges.avg == FALSE) {
+        out$casl$edges <- (netparams$casl$md.casl * num) / 2
+      } else {
+        out$casl$edges <- sum(unname(table(out$attr$race)) * netparams$casl$nf.race) / 2
+      }
+      # nodefactor("race") ---
+      nodefactor_race <- table(out$attr$race) * netparams$casl$nf.race
+      out$casl$nodefactor_race <- unname(nodefactor_race)
+
+      # nodematch("race") ---
+      nodematch_race <- nodefactor_race / 2 * netparams$casl$nm.race
+      out$casl$nodematch_race <- unname(nodematch_race)
+
+      # nodematch("race", diff = FALSE) ---
+      nodematch_race <- out$casl$edges * netparams$casl$nm.race_diffF
+      out$casl$nodematch_race_diffF <- unname(nodematch_race)
     } else {
-      out$casl$edges <- sum(unname(table(out$attr$race)) * netparams$casl$nf.race) / 2
+      out$casl$edges <- (netparams$casl$md.casl * num) / 2
     }
-    # nodefactor("race") ---
-    nodefactor_race <- table(out$attr$race) * netparams$casl$nf.race
-    out$casl$nodefactor_race <- unname(nodefactor_race)
 
-    # nodematch("race") ---
-    nodematch_race <- nodefactor_race / 2 * netparams$casl$nm.race
-    out$casl$nodematch_race <- unname(nodematch_race)
+    # nodefactor("age.grp") ---
+    nodefactor_age.grp <- table(out$attr$age.grp) * netparams$casl$nf.age.grp
+    if (sex.cess.mod == TRUE) {
+      nodefactor_age.grp[length(nodefactor_age.grp)] <- 0
+    }
+    out$casl$nodefactor_age.grp <- unname(nodefactor_age.grp)
 
-    # nodematch("race", diff = FALSE) ---
-    nodematch_race <- out$casl$edges * netparams$casl$nm.race_diffF
-    out$casl$nodematch_race_diffF <- unname(nodematch_race)
-  } else {
-    out$casl$edges <- (netparams$casl$md.casl * num) / 2
+    # nodematch("age.grp") ---
+    nodematch_age.grp <- nodefactor_age.grp / 2 * netparams$casl$nm.age.grp
+    out$casl$nodematch_age.grp <- unname(nodematch_age.grp)
+
+    # absdiff("age") ---
+    absdiff_age <- out$casl$edges * netparams$casl$absdiff.age
+    out$casl$absdiff_age <- absdiff_age
+
+    # absdiff("sqrt.age") ---
+    absdiff_sqrt.age <- out$casl$edges * netparams$casl$absdiff.sqrt.age
+    out$casl$absdiff_sqrt.age <- absdiff_sqrt.age
+
+    # nodefactor("deg.main") ---
+    out$casl$nodefactor_deg.main <- num * netparams$casl$deg.main.dist * netparams$casl$nf.deg.main
+
+    # concurrent ---
+    out$casl$concurrent <- num * netparams$casl$concurrent
+
+    # nodefactor("diag.status") ---
+    nodefactor_diag.status <- table(out$attr$diag.status) * netparams$casl$nf.diag.status
+    out$casl$nodefactor_diag.status <- unname(nodefactor_diag.status)
+
+  } else {  # method == "joint"
+
+    out$casl$edges <- sum(pred_deg_casl) / 2
+
+    if (race == TRUE) {
+      n_race <- length(netparams$casl$nf.race)
+      out$casl$nodefactor_race <- vapply(seq_len(n_race),
+        function(r) sum(pred_deg_casl[out$attr$race == r]), numeric(1))
+      out$casl$nodematch_race <- unname(
+        out$casl$nodefactor_race / 2 * netparams$casl$nm.race)
+      out$casl$nodematch_race_diffF <- unname(
+        out$casl$edges * netparams$casl$nm.race_diffF)
+    }
+
+    n_age <- length(netparams$casl$nf.age.grp)
+    out$casl$nodefactor_age.grp <- vapply(seq_len(n_age),
+      function(k) sum(pred_deg_casl[out$attr$age.grp == k]), numeric(1))
+
+    out$casl$nodematch_age.grp <- unname(
+      out$casl$nodefactor_age.grp / 2 * netparams$casl$nm.age.grp)
+
+    out$casl$absdiff_age <- out$casl$edges * netparams$casl$absdiff.age
+    out$casl$absdiff_sqrt.age <- out$casl$edges * netparams$casl$absdiff.sqrt.age
+
+    # nodefactor("deg.main") -- truncated at 2 in build_netparams
+    out$casl$nodefactor_deg.main <- vapply(0:2,
+      function(d) sum(pred_deg_casl[out$attr$deg.main == d]), numeric(1))
+
+    # concurrent -- see note in main layer block. Truncation of deg.casl
+    # at 3 in the training data makes Poisson-implied P(deg > 1)
+    # unreliable; retain the univariate binomial fit.
+    out$casl$concurrent <- num * netparams$casl$concurrent
+
+    out$casl$nodefactor_diag.status <- vapply(0:1,
+      function(h) sum(pred_deg_casl[out$attr$diag.status == h]), numeric(1))
   }
 
-  # nodefactor("age.grp") ---
-  nodefactor_age.grp <- table(out$attr$age.grp) * netparams$casl$nf.age.grp
-  if (sex.cess.mod == TRUE) {
-    nodefactor_age.grp[length(nodefactor_age.grp)] <- 0
-  }
-  out$casl$nodefactor_age.grp <- unname(nodefactor_age.grp)
-
-  # nodematch("age.grp") ---
-  nodematch_age.grp <- nodefactor_age.grp / 2 * netparams$casl$nm.age.grp
-  out$casl$nodematch_age.grp <- unname(nodematch_age.grp)
-
-  # absdiff("age") ---
-  absdiff_age <- out$casl$edges * netparams$casl$absdiff.age
-  out$casl$absdiff_age <- absdiff_age
-
-  # absdiff("sqrt.age") ---
-  absdiff_sqrt.age <- out$casl$edges * netparams$casl$absdiff.sqrt.age
-  out$casl$absdiff_sqrt.age <- absdiff_sqrt.age
-
-  # nodefactor("deg.main") ---
-  out$casl$nodefactor_deg.main <- num * netparams$casl$deg.main.dist * netparams$casl$nf.deg.main
-
-  # concurrent ---
-  out$casl$concurrent <- num * netparams$casl$concurrent
-
-  # nodefactor("diag.status") ---
-  nodefactor_diag.status <- table(out$attr$diag.status) * netparams$casl$nf.diag.status
-  out$casl$nodefactor_diag.status <- unname(nodefactor_diag.status)
-
-  # Dissolution
+  # Dissolution (identical under both methods)
   out$casl$diss.homog <- dissolution_coefs(dissolution = ~offset(edges),
                                            duration = netparams$casl$durs.casl.homog$mean.dur.adj,
                                            d.rate = expect.mort)
@@ -505,58 +654,96 @@ build_netstats <- function(epistats, netparams,
 
   out$inst <- list()
 
-  # edges ---
-  if (race == TRUE) {
-    if (edges.avg == FALSE) {
-      out$inst$edges <- (netparams$inst$md.inst * num) / 2
+  if (method == "existing") {
+
+    # edges ---
+    if (race == TRUE) {
+      if (edges.avg == FALSE) {
+        out$inst$edges <- (netparams$inst$md.inst * num) / 2
+      } else {
+        out$inst$edges <- sum(unname(table(out$attr$race)) * netparams$inst$nf.race) / 2
+      }
+      # nodefactor("race") ---
+      nodefactor_race <- table(out$attr$race) * netparams$inst$nf.race
+      out$inst$nodefactor_race <- unname(nodefactor_race)
+
+      # nodematch("race") ---
+      nodematch_race <- nodefactor_race / 2 * netparams$inst$nm.race
+      out$inst$nodematch_race <- unname(nodematch_race)
+
+      # nodematch("race", diff = FALSE) ---
+      nodematch_race <- out$inst$edges * netparams$inst$nm.race_diffF
+      out$inst$nodematch_race_diffF <- unname(nodematch_race)
     } else {
-      out$inst$edges <- sum(unname(table(out$attr$race)) * netparams$inst$nf.race) / 2
+      out$inst$edges <- (netparams$inst$md.inst * num) / 2
     }
-    # nodefactor("race") ---
-    nodefactor_race <- table(out$attr$race) * netparams$inst$nf.race
-    out$inst$nodefactor_race <- unname(nodefactor_race)
 
-    # nodematch("race") ---
-    nodematch_race <- nodefactor_race / 2 * netparams$inst$nm.race
-    out$inst$nodematch_race <- unname(nodematch_race)
+    # nodefactor("age.grp") ---
+    nodefactor_age.grp <- table(out$attr$age.grp) * netparams$inst$nf.age.grp
+    if (sex.cess.mod == TRUE) {
+      nodefactor_age.grp[length(nodefactor_age.grp)] <- 0
+    }
+    out$inst$nodefactor_age.grp <- unname(nodefactor_age.grp)
 
-    # nodematch("race", diff = FALSE) ---
-    nodematch_race <- out$inst$edges * netparams$inst$nm.race_diffF
-    out$inst$nodematch_race_diffF <- unname(nodematch_race)
-  } else {
-    out$inst$edges <- (netparams$inst$md.inst * num) / 2
+    # nodematch("age.grp") ---
+    nodematch_age.grp <- nodefactor_age.grp / 2 * netparams$inst$nm.age.grp
+    out$inst$nodematch_age.grp <- unname(nodematch_age.grp)
+
+    # absdiff("age") ---
+    absdiff_age <- out$inst$edges * netparams$inst$absdiff.age
+    out$inst$absdiff_age <- absdiff_age
+
+    # absdiff("sqrt.age") ---
+    absdiff_sqrt.age <- out$inst$edges * netparams$inst$absdiff.sqrt.age
+    out$inst$absdiff_sqrt.age <- absdiff_sqrt.age
+
+    # nodefactor("risk.grp") ---
+    nodefactor_risk.grp <- table(out$attr$risk.grp) * netparams$inst$nf.risk.grp
+    out$inst$nodefactor_risk.grp <- unname(nodefactor_risk.grp)
+
+    # nodefactor("deg.tot") ---
+    nodefactor_deg.tot <- table(out$attr$deg.tot) * netparams$inst$nf.deg.tot
+    out$inst$nodefactor_deg.tot <- unname(nodefactor_deg.tot)
+
+    # nodefactor("diag.status") ---
+    nodefactor_diag.status <- table(out$attr$diag.status) * netparams$inst$nf.diag.status
+    out$inst$nodefactor_diag.status <- unname(nodefactor_diag.status)
+
+  } else {  # method == "joint"
+
+    out$inst$edges <- sum(pred_deg_inst) / 2
+
+    if (race == TRUE) {
+      n_race <- length(netparams$inst$nf.race)
+      out$inst$nodefactor_race <- vapply(seq_len(n_race),
+        function(r) sum(pred_deg_inst[out$attr$race == r]), numeric(1))
+      out$inst$nodematch_race <- unname(
+        out$inst$nodefactor_race / 2 * netparams$inst$nm.race)
+      out$inst$nodematch_race_diffF <- unname(
+        out$inst$edges * netparams$inst$nm.race_diffF)
+    }
+
+    n_age <- length(netparams$inst$nf.age.grp)
+    out$inst$nodefactor_age.grp <- vapply(seq_len(n_age),
+      function(k) sum(pred_deg_inst[out$attr$age.grp == k]), numeric(1))
+
+    out$inst$nodematch_age.grp <- unname(
+      out$inst$nodefactor_age.grp / 2 * netparams$inst$nm.age.grp)
+
+    out$inst$absdiff_age <- out$inst$edges * netparams$inst$absdiff.age
+    out$inst$absdiff_sqrt.age <- out$inst$edges * netparams$inst$absdiff.sqrt.age
+
+    # nodefactor("risk.grp") -- quantile-scheme preserved from univariate
+    nodefactor_risk.grp <- table(out$attr$risk.grp) * netparams$inst$nf.risk.grp
+    out$inst$nodefactor_risk.grp <- unname(nodefactor_risk.grp)
+
+    # nodefactor("deg.tot") -- truncated at 3 in build_netparams
+    out$inst$nodefactor_deg.tot <- vapply(0:3,
+      function(d) sum(pred_deg_inst[out$attr$deg.tot == d]), numeric(1))
+
+    out$inst$nodefactor_diag.status <- vapply(0:1,
+      function(h) sum(pred_deg_inst[out$attr$diag.status == h]), numeric(1))
   }
-
-  # nodefactor("age.grp") ---
-  nodefactor_age.grp <- table(out$attr$age.grp) * netparams$inst$nf.age.grp
-  if (sex.cess.mod == TRUE) {
-    nodefactor_age.grp[length(nodefactor_age.grp)] <- 0
-  }
-  out$inst$nodefactor_age.grp <- unname(nodefactor_age.grp)
-
-  # nodematch("age.grp") ---
-  nodematch_age.grp <- nodefactor_age.grp / 2 * netparams$inst$nm.age.grp
-  out$inst$nodematch_age.grp <- unname(nodematch_age.grp)
-
-  # absdiff("age") ---
-  absdiff_age <- out$inst$edges * netparams$inst$absdiff.age
-  out$inst$absdiff_age <- absdiff_age
-
-  # absdiff("sqrt.age") ---
-  absdiff_sqrt.age <- out$inst$edges * netparams$inst$absdiff.sqrt.age
-  out$inst$absdiff_sqrt.age <- absdiff_sqrt.age
-
-  # nodefactor("risk.grp") ---
-  nodefactor_risk.grp <- table(out$attr$risk.grp) * netparams$inst$nf.risk.grp
-  out$inst$nodefactor_risk.grp <- unname(nodefactor_risk.grp)
-
-  # nodefactor("deg.tot") ---
-  nodefactor_deg.tot <- table(out$attr$deg.tot) * netparams$inst$nf.deg.tot
-  out$inst$nodefactor_deg.tot <- unname(nodefactor_deg.tot)
-
-  # nodefactor("diag.status") ---
-  nodefactor_diag.status <- table(out$attr$diag.status) * netparams$inst$nf.diag.status
-  out$inst$nodefactor_diag.status <- unname(nodefactor_diag.status)
 
 
   return(out)

--- a/R/NetStats.R
+++ b/R/NetStats.R
@@ -26,14 +26,14 @@
 #'        `netparams`. `"joint"` uses the joint Poisson GLM fit at `netparams$<layer>$joint_model`
 #'        (set by `build_netparams(..., method = "joint")`) to predict expected degree for each
 #'        synthetic-population node and aggregates via g-computation:
-#'        `edges = sum(pred) / 2` and `nodefactor_<attr>[level] = sum(pred[attr == level])`.
-#'        Under `"joint"`, edges and all nodefactor target stats are internally consistent by
-#'        construction (`sum(nodefactor_<attr>) = 2 * edges`), so `edges.avg` has no effect.
-#'        `nodematch_*`, `absdiff_*`, dissolution coefficients, `concurrent`, and
-#'        `nodefactor_risk.grp` continue to use the univariate marginals — those are scoped for
-#'        later issues (#63–#64). `concurrent` in particular is retained from the univariate
-#'        binomial fit because the joint Poisson's implied `P(deg > 1)` is biased by the
-#'        truncation of `deg.main` and `deg.casl` in the training data.
+#'        `edges = sum(pred) / 2` and `nodefactor_<attr>[level] = sum(pred[attr == level])`. The
+#'        `concurrent` target for the main and casual layers uses a parallel joint binomial GLM
+#'        fit on the `deg > 1` indicator (`netparams$<layer>$joint_concurrent_model`), so
+#'        `concurrent = sum(P(deg > 1 | attrs))` per node. Under `"joint"`, edges and all
+#'        nodefactor target stats are internally consistent by construction
+#'        (`sum(nodefactor_<attr>) = 2 * edges`), so `edges.avg` has no effect. `nodematch_*`,
+#'        `absdiff_*`, dissolution coefficients, and `nodefactor_risk.grp` continue to use the
+#'        univariate marginals — those are scoped for later issues (#63–#64).
 #' @param browser If `TRUE`, run `build_netparams` in interactive browser mode.
 #'
 #' @details
@@ -422,11 +422,22 @@ build_netstats <- function(epistats, netparams,
     pred_count_inst <- predict(netparams$inst$joint_model, newdata = synth, type = "response")
     pred_deg_inst   <- pred_count_inst / (364 / time.unit)
 
+    # Concurrency probabilities from the joint binomial GLMs on the
+    # deg.{main,casl}.conc indicators (fit alongside the Poisson in
+    # build_netparams under method = "joint"). No concurrent target for
+    # the one-off layer.
+    pred_conc_main <- predict(netparams$main$joint_concurrent_model,
+                              newdata = synth, type = "response")
+    pred_conc_casl <- predict(netparams$casl$joint_concurrent_model,
+                              newdata = synth, type = "response")
+
     if (sex.cess.mod == TRUE) {
       inactive <- out$attr$active.sex == 0L
-      pred_deg_main[inactive] <- 0
-      pred_deg_casl[inactive] <- 0
-      pred_deg_inst[inactive] <- 0
+      pred_deg_main[inactive]  <- 0
+      pred_deg_casl[inactive]  <- 0
+      pred_deg_inst[inactive]  <- 0
+      pred_conc_main[inactive] <- 0
+      pred_conc_casl[inactive] <- 0
     }
   }
 
@@ -521,14 +532,8 @@ build_netstats <- function(epistats, netparams,
     out$main$nodefactor_deg.casl <- vapply(0:3,
       function(d) sum(pred_deg_main[out$attr$deg.casl == d]), numeric(1))
 
-    # concurrent -- keep the univariate binomial unchanged. The Poisson
-    # joint model's implied P(deg > 1) = 1 - exp(-lambda)(1+lambda) would
-    # inflate this ~5x because deg.main is truncated at 2 in the training
-    # data, so the fitted lambda approximates E[min(deg, 2)] rather than
-    # the true Poisson rate. The binomial logistic fit is the right model
-    # for the probability of concurrency; joint-modeling it is scoped to
-    # a separate issue.
-    out$main$concurrent <- num * netparams$main$concurrent
+    # concurrent from the joint binomial GLM on deg.main.conc ----------------
+    out$main$concurrent <- sum(pred_conc_main)
 
     # nodefactor("diag.status") ---------------------------------------------
     out$main$nodefactor_diag.status <- vapply(0:1,
@@ -631,10 +636,8 @@ build_netstats <- function(epistats, netparams,
     out$casl$nodefactor_deg.main <- vapply(0:2,
       function(d) sum(pred_deg_casl[out$attr$deg.main == d]), numeric(1))
 
-    # concurrent -- see note in main layer block. Truncation of deg.casl
-    # at 3 in the training data makes Poisson-implied P(deg > 1)
-    # unreliable; retain the univariate binomial fit.
-    out$casl$concurrent <- num * netparams$casl$concurrent
+    # concurrent from the joint binomial GLM on deg.casl.conc ----------------
+    out$casl$concurrent <- sum(pred_conc_casl)
 
     out$casl$nodefactor_diag.status <- vapply(0:1,
       function(h) sum(pred_deg_casl[out$attr$diag.status == h]), numeric(1))

--- a/inst/validation/validate_backward_compat.R
+++ b/inst/validation/validate_backward_compat.R
@@ -92,9 +92,11 @@ PARAM_SETS <- list(
   netparams
 }
 
-# Run one parameter set end-to-end. `netparams_extra` lets the caller pass
-# e.g. method = "existing" post-refactor without affecting the pre-capture.
-.run_one <- function(set, netparams_extra = list()) {
+# Run one parameter set end-to-end. `netparams_extra` and `netstats_extra`
+# let the caller pass e.g. method = "existing" post-refactor without
+# affecting the pre-capture. The convenience `method` arg threads a single
+# value to both functions (the common case).
+.run_one <- function(set, netparams_extra = list(), netstats_extra = list()) {
   set.seed(.VALIDATION_SEED)
   epistats <- do.call(ARTnet::build_epistats, set$epistats)
 
@@ -102,7 +104,7 @@ PARAM_SETS <- list(
   netparams <- do.call(ARTnet::build_netparams, netparams_args)
 
   netstats_args <- c(list(epistats = epistats, netparams = netparams),
-                     set$netstats)
+                     set$netstats, netstats_extra)
   netstats <- do.call(ARTnet::build_netstats, netstats_args)
 
   list(netparams = netparams, netstats = netstats)
@@ -142,15 +144,25 @@ capture_snapshot <- function(overwrite = FALSE) {
 #' joint g-comp refactor should pass this with zero diffs when the legacy
 #' code path is selected (e.g. `method = "existing"`).
 #'
-#' @param ... Passed as additional args to `build_netparams()`. For the
-#'   refactor branch this will typically be `method = "existing"` once the
-#'   arg exists; on the pre-refactor branch leave empty.
+#' @param method If non-NULL, a single value passed as `method = <val>` to
+#'   **both** `build_netparams()` and `build_netstats()`. This is the common
+#'   case (symmetric method) — pass `method = "existing"` to compare legacy
+#'   behavior against snapshots. For asymmetric testing, use the low-level
+#'   `netparams_extra` / `netstats_extra` args.
+#' @param netparams_extra,netstats_extra Named lists of extra args forwarded
+#'   to the respective functions.
 #' @param tolerance Numeric tolerance for `all.equal()`. Default 0 (exact).
 #' @return Invisibly: TRUE iff all sets match; FALSE otherwise.
-compare_to_snapshot <- function(..., tolerance = 0) {
+compare_to_snapshot <- function(method = NULL,
+                                netparams_extra = list(),
+                                netstats_extra = list(),
+                                tolerance = 0) {
   .require_artnetdata()
   dir <- .snapshot_dir()
-  netparams_extra <- list(...)
+  if (!is.null(method)) {
+    netparams_extra$method <- method
+    netstats_extra$method  <- method
+  }
 
   overall_ok <- TRUE
   for (set in PARAM_SETS) {
@@ -163,7 +175,8 @@ compare_to_snapshot <- function(..., tolerance = 0) {
     }
     message("COMPARE: ", set$name)
     ref <- readRDS(path)
-    cur <- .run_one(set, netparams_extra = netparams_extra)
+    cur <- .run_one(set, netparams_extra = netparams_extra,
+                    netstats_extra = netstats_extra)
 
     np_ref <- .strip_additive(ref$netparams)
     np_cur <- .strip_additive(cur$netparams)

--- a/inst/validation/validate_backward_compat.R
+++ b/inst/validation/validate_backward_compat.R
@@ -88,6 +88,7 @@ PARAM_SETS <- list(
   for (layer in c("main", "casl", "inst", "all")) {
     if (is.null(netparams[[layer]])) next
     netparams[[layer]]$joint_model <- NULL
+    netparams[[layer]]$joint_concurrent_model <- NULL
   }
   netparams
 }

--- a/man/build_netparams.Rd
+++ b/man/build_netparams.Rd
@@ -24,11 +24,12 @@ of one-off partners per unit time).}
 \item{method}{Character. Either \code{"existing"} (default) or \code{"joint"}. \code{"existing"} reproduces
 the pre-refactor behavior byte-for-byte: a separate univariate Poisson/binomial GLM is
 fit for each ERGM target statistic. \code{"joint"} leaves all of those outputs intact \strong{and}
-additionally fits one joint Poisson GLM per layer (main/casual/one-off) predicting
-degree (or one-off partner count) from all attributes simultaneously, with AIC-based
-interaction selection. The fitted objects are returned at \verb{$main$joint_model},
-\verb{$casl$joint_model}, and \verb{$inst$joint_model} and form the basis of the g-computation
-refactor planned for \code{\link{build_netstats}} in a later release.}
+additionally fits joint GLMs per layer with AIC-based interaction selection:
+a Poisson model for degree (main/casual) or one-off partner count (inst), stored at
+\verb{$<layer>$joint_model}; and, for the main and casual layers, a binomial model for the
+concurrency indicator (\code{deg > 1}), stored at \verb{$<layer>$joint_concurrent_model}. These
+models are consumed by \code{\link{build_netstats}} under \code{method = "joint"} to produce
+internally-consistent g-computation target statistics.}
 
 \item{browser}{If \code{TRUE}, run \code{build_netparams} in interactive browser mode.}
 }

--- a/man/build_netstats.Rd
+++ b/man/build_netstats.Rd
@@ -47,14 +47,14 @@ concurrent are computed layer-by-layer from the univariate marginal fits stored 
 \code{netparams}. \code{"joint"} uses the joint Poisson GLM fit at \verb{netparams$<layer>$joint_model}
 (set by \code{build_netparams(..., method = "joint")}) to predict expected degree for each
 synthetic-population node and aggregates via g-computation:
-\code{edges = sum(pred) / 2} and \verb{nodefactor_<attr>[level] = sum(pred[attr == level])}.
-Under \code{"joint"}, edges and all nodefactor target stats are internally consistent by
-construction (\verb{sum(nodefactor_<attr>) = 2 * edges}), so \code{edges.avg} has no effect.
-\verb{nodematch_*}, \verb{absdiff_*}, dissolution coefficients, \code{concurrent}, and
-\code{nodefactor_risk.grp} continue to use the univariate marginals — those are scoped for
-later issues (#63–#64). \code{concurrent} in particular is retained from the univariate
-binomial fit because the joint Poisson's implied \code{P(deg > 1)} is biased by the
-truncation of \code{deg.main} and \code{deg.casl} in the training data.}
+\code{edges = sum(pred) / 2} and \verb{nodefactor_<attr>[level] = sum(pred[attr == level])}. The
+\code{concurrent} target for the main and casual layers uses a parallel joint binomial GLM
+fit on the \code{deg > 1} indicator (\verb{netparams$<layer>$joint_concurrent_model}), so
+\code{concurrent = sum(P(deg > 1 | attrs))} per node. Under \code{"joint"}, edges and all
+nodefactor target stats are internally consistent by construction
+(\verb{sum(nodefactor_<attr>) = 2 * edges}), so \code{edges.avg} has no effect. \verb{nodematch_*},
+\verb{absdiff_*}, dissolution coefficients, and \code{nodefactor_risk.grp} continue to use the
+univariate marginals — those are scoped for later issues (#63–#64).}
 
 \item{browser}{If \code{TRUE}, run \code{build_netparams} in interactive browser mode.}
 }

--- a/man/build_netstats.Rd
+++ b/man/build_netstats.Rd
@@ -13,6 +13,7 @@ build_netstats(
   edges.avg = FALSE,
   race.prop = NULL,
   young.prop = NULL,
+  method = c("existing", "joint"),
   browser = FALSE
 )
 }
@@ -39,6 +40,21 @@ Hispanic, and White/Other).}
 \item{young.prop}{The proportion of the population that should be below the age of sexual cessation.
 Default is NULL (meaning no re-weighting of the \code{age.pyramid} parameter is performed).
 This parameter is only used if the age of sexual cessation is less than the upper age bound.}
+
+\item{method}{Character. Either \code{"existing"} (default) or \code{"joint"}. \code{"existing"} reproduces
+the pre-refactor behavior byte-for-byte: target statistics for edges, nodefactor, and
+concurrent are computed layer-by-layer from the univariate marginal fits stored on
+\code{netparams}. \code{"joint"} uses the joint Poisson GLM fit at \verb{netparams$<layer>$joint_model}
+(set by \code{build_netparams(..., method = "joint")}) to predict expected degree for each
+synthetic-population node and aggregates via g-computation:
+\code{edges = sum(pred) / 2} and \verb{nodefactor_<attr>[level] = sum(pred[attr == level])}.
+Under \code{"joint"}, edges and all nodefactor target stats are internally consistent by
+construction (\verb{sum(nodefactor_<attr>) = 2 * edges}), so \code{edges.avg} has no effect.
+\verb{nodematch_*}, \verb{absdiff_*}, dissolution coefficients, \code{concurrent}, and
+\code{nodefactor_risk.grp} continue to use the univariate marginals — those are scoped for
+later issues (#63–#64). \code{concurrent} in particular is retained from the univariate
+binomial fit because the joint Poisson's implied \code{P(deg > 1)} is biased by the
+truncation of \code{deg.main} and \code{deg.casl} in the training data.}
 
 \item{browser}{If \code{TRUE}, run \code{build_netparams} in interactive browser mode.}
 }

--- a/tests/testthat/test-joint-model.R
+++ b/tests/testthat/test-joint-model.R
@@ -45,6 +45,26 @@ test_that("method='joint' adds a converged glm per layer", {
   }
 })
 
+test_that("method='joint' adds a converged concurrent binomial for main/casl", {
+  skip_without_artnetdata()
+  np <- get_netparams("joint")
+  for (layer in c("main", "casl")) {
+    m <- np[[layer]]$joint_concurrent_model
+    expect_s3_class(m, "glm")
+    expect_true(isTRUE(m$converged),
+                info = paste("joint_concurrent_model did not converge for", layer))
+    expect_identical(m$family$family, "binomial")
+    # Marginal recovery on training data
+    col <- paste0("deg.", layer, ".conc")
+    obs <- mean(m$data[[col]], na.rm = TRUE)
+    pred <- mean(predict(m, type = "response"))
+    expect_lt(abs(pred - obs) / obs, 0.01,
+              label = paste0("[", layer, "] concurrent marginal recovery"))
+  }
+  # inst has no concurrent target, so no concurrent model
+  expect_null(np$inst$joint_concurrent_model)
+})
+
 test_that("joint models recover observed marginal means within 1%", {
   skip_without_artnetdata()
   np <- get_netparams("joint")
@@ -91,9 +111,10 @@ test_that("method='joint' leaves existing marginal fields untouched", {
   skip_without_artnetdata()
   np_existing <- get_netparams("existing")
   np_joint <- get_netparams("joint")
+  additive_fields <- c("joint_model", "joint_concurrent_model")
   for (layer in c("main", "casl", "inst", "all")) {
     if (is.null(np_existing[[layer]])) next
-    fields <- setdiff(names(np_existing[[layer]]), "joint_model")
+    fields <- setdiff(names(np_existing[[layer]]), additive_fields)
     for (f in fields) {
       expect_equal(np_joint[[layer]][[f]], np_existing[[layer]][[f]],
                    info = paste0("[", layer, "$", f, "] diverged under joint"))

--- a/tests/testthat/test-joint-netstats.R
+++ b/tests/testthat/test-joint-netstats.R
@@ -95,13 +95,26 @@ test_that("joint netstats preserve non-refactored fields exactly", {
   joint    <- get_stats("joint", "joint")$netstats
   # risk.grp nodefactor (inst) is NOT refactored — keeps univariate.
   expect_equal(existing$inst$nodefactor_risk.grp, joint$inst$nodefactor_risk.grp)
-  # concurrent is NOT refactored (truncation bias in Poisson-derived P(deg>1)).
-  expect_equal(existing$main$concurrent, joint$main$concurrent)
-  expect_equal(existing$casl$concurrent, joint$casl$concurrent)
   # attributes are sampled identically when seeded, so they should match
   expect_equal(existing$attr, joint$attr)
   # demography likewise unchanged
   expect_equal(existing$demog$num, joint$demog$num)
+})
+
+test_that("joint concurrent is in a reasonable range (not inflated by Poisson)", {
+  skip_without_artnetdata()
+  existing <- get_stats("existing", "existing")$netstats
+  joint    <- get_stats("joint", "joint")$netstats
+  # Joint concurrent should stay in the same order of magnitude as existing.
+  # A Poisson-derived P(deg>1) would inflate main concurrent ~5x because of
+  # the deg.main truncation at 2 in the training data; the binomial joint
+  # model avoids that.
+  ratio_main <- joint$main$concurrent / existing$main$concurrent
+  expect_gt(ratio_main, 0.5)
+  expect_lt(ratio_main, 2.0)
+  ratio_casl <- joint$casl$concurrent / existing$casl$concurrent
+  expect_gt(ratio_casl, 0.5)
+  expect_lt(ratio_casl, 2.0)
 })
 
 test_that("joint edges differ materially from existing when population shifts", {

--- a/tests/testthat/test-joint-netstats.R
+++ b/tests/testthat/test-joint-netstats.R
@@ -1,0 +1,157 @@
+# Tests for the method = "joint" path added to build_netstats() in issue #62.
+
+skip_without_artnetdata <- function() {
+  testthat::skip_if(system.file(package = "ARTnetData") == "",
+                    "ARTnetData not installed")
+}
+
+cache_env <- new.env(parent = emptyenv())
+
+get_stats <- function(netparams_method, netstats_method) {
+  key <- paste0(netparams_method, "_", netstats_method)
+  if (!is.null(cache_env[[key]])) return(cache_env[[key]])
+
+  set.seed(20260419L)
+  epistats <- build_epistats(
+    geog.lvl = "city", geog.cat = "Atlanta",
+    init.hiv.prev = c(0.33, 0.137, 0.084),
+    race = TRUE, time.unit = 7
+  )
+  set.seed(20260419L)
+  np <- build_netparams(epistats, smooth.main.dur = TRUE, method = netparams_method)
+  set.seed(20260419L)
+  ns <- build_netstats(epistats, np,
+                      expect.mort = 0.000478213, network.size = 5000,
+                      method = netstats_method)
+  out <- list(epistats = epistats, netparams = np, netstats = ns)
+  cache_env[[key]] <- out
+  out
+}
+
+test_that("method = 'joint' requires netparams built with method = 'joint'", {
+  skip_without_artnetdata()
+  set.seed(20260419L)
+  epistats <- build_epistats(
+    geog.lvl = "city", geog.cat = "Atlanta",
+    init.hiv.prev = c(0.33, 0.137, 0.084),
+    race = TRUE, time.unit = 7
+  )
+  set.seed(20260419L)
+  np_existing <- build_netparams(epistats, smooth.main.dur = TRUE,
+                                 method = "existing")
+  expect_error(
+    build_netstats(epistats, np_existing,
+                   expect.mort = 0.000478213, network.size = 5000,
+                   method = "joint"),
+    regexp = "method = 'joint' requires netparams"
+  )
+})
+
+test_that("joint netstats are internally consistent: 2 * edges == sum(nodefactor_*)", {
+  skip_without_artnetdata()
+  ns <- get_stats("joint", "joint")$netstats
+  for (layer in c("main", "casl", "inst")) {
+    e <- ns[[layer]]$edges
+    expect_equal(sum(ns[[layer]]$nodefactor_race),      2 * e,
+                 tolerance = 1e-9,
+                 info = paste0(layer, ": 2*edges vs sum(nf_race)"))
+    expect_equal(sum(ns[[layer]]$nodefactor_age.grp),   2 * e,
+                 tolerance = 1e-9,
+                 info = paste0(layer, ": 2*edges vs sum(nf_age.grp)"))
+    expect_equal(sum(ns[[layer]]$nodefactor_diag.status), 2 * e,
+                 tolerance = 1e-9,
+                 info = paste0(layer, ": 2*edges vs sum(nf_diag.status)"))
+  }
+  # Layer-specific deg-attr nodefactor sums
+  expect_equal(sum(ns$main$nodefactor_deg.casl), 2 * ns$main$edges,
+               tolerance = 1e-9)
+  expect_equal(sum(ns$casl$nodefactor_deg.main), 2 * ns$casl$edges,
+               tolerance = 1e-9)
+  expect_equal(sum(ns$inst$nodefactor_deg.tot),  2 * ns$inst$edges,
+               tolerance = 1e-9)
+})
+
+test_that("joint netstats preserve existing dissolution coefs (numeric content)", {
+  skip_without_artnetdata()
+  existing <- get_stats("existing", "existing")$netstats
+  joint    <- get_stats("joint", "joint")$netstats
+  # dissolution_coefs() returns a list containing a formula, which captures
+  # the caller's scope environment — so full-object expect_equal() differs
+  # between the existing and joint code paths even though coefficients,
+  # durations, and rates are identical. Compare numeric content only.
+  diss_numeric <- function(x) {
+    x$dissolution <- NULL  # drop formula/env
+    x
+  }
+  expect_equal(diss_numeric(existing$main$diss.homog), diss_numeric(joint$main$diss.homog))
+  expect_equal(diss_numeric(existing$main$diss.byage), diss_numeric(joint$main$diss.byage))
+  expect_equal(diss_numeric(existing$casl$diss.homog), diss_numeric(joint$casl$diss.homog))
+  expect_equal(diss_numeric(existing$casl$diss.byage), diss_numeric(joint$casl$diss.byage))
+})
+
+test_that("joint netstats preserve non-refactored fields exactly", {
+  skip_without_artnetdata()
+  existing <- get_stats("existing", "existing")$netstats
+  joint    <- get_stats("joint", "joint")$netstats
+  # risk.grp nodefactor (inst) is NOT refactored — keeps univariate.
+  expect_equal(existing$inst$nodefactor_risk.grp, joint$inst$nodefactor_risk.grp)
+  # concurrent is NOT refactored (truncation bias in Poisson-derived P(deg>1)).
+  expect_equal(existing$main$concurrent, joint$main$concurrent)
+  expect_equal(existing$casl$concurrent, joint$casl$concurrent)
+  # attributes are sampled identically when seeded, so they should match
+  expect_equal(existing$attr, joint$attr)
+  # demography likewise unchanged
+  expect_equal(existing$demog$num, joint$demog$num)
+})
+
+test_that("joint edges differ materially from existing when population shifts", {
+  skip_without_artnetdata()
+  # Run under a race distribution that diverges from Atlanta defaults.
+  set.seed(20260419L)
+  epistats <- build_epistats(
+    geog.lvl = "city", geog.cat = "Atlanta",
+    init.hiv.prev = c(0.33, 0.137, 0.084),
+    race = TRUE, time.unit = 7
+  )
+  set.seed(20260419L)
+  np <- build_netparams(epistats, smooth.main.dur = TRUE, method = "joint")
+  set.seed(20260419L)
+  ns_ex <- build_netstats(epistats, np,
+                          expect.mort = 0.000478213, network.size = 5000,
+                          race.prop = c(0.35, 0.25, 0.40),
+                          method = "existing")
+  set.seed(20260419L)
+  ns_jt <- build_netstats(epistats, np,
+                          expect.mort = 0.000478213, network.size = 5000,
+                          race.prop = c(0.35, 0.25, 0.40),
+                          method = "joint")
+  # Expect >1% divergence between methods on at least one layer under a
+  # shifted population — this is the empirical point of the refactor.
+  divergence <- abs(ns_jt$main$edges - ns_ex$main$edges) / ns_ex$main$edges
+  expect_gt(divergence, 0.01)
+  # Joint stays internally consistent even with shifted race.prop.
+  expect_equal(sum(ns_jt$main$nodefactor_race), 2 * ns_jt$main$edges,
+               tolerance = 1e-9)
+})
+
+test_that("joint netstats work with race = FALSE", {
+  skip_without_artnetdata()
+  set.seed(20260419L)
+  epistats <- build_epistats(
+    geog.lvl = "city", geog.cat = "Atlanta",
+    init.hiv.prev = c(0.33, 0.137, 0.084),
+    race = FALSE, time.unit = 7
+  )
+  set.seed(20260419L)
+  np <- build_netparams(epistats, smooth.main.dur = TRUE, method = "joint")
+  set.seed(20260419L)
+  ns <- build_netstats(epistats, np,
+                       expect.mort = 0.000478213, network.size = 5000,
+                       method = "joint")
+  # race nodefactor/match not populated when race = FALSE
+  expect_null(ns$main$nodefactor_race)
+  expect_null(ns$main$nodematch_race)
+  # but edges and age.grp still internally consistent
+  expect_equal(sum(ns$main$nodefactor_age.grp), 2 * ns$main$edges,
+               tolerance = 1e-9)
+})


### PR DESCRIPTION
## Summary

Adds `method = c("existing", "joint")` to `build_netstats()`. Under `method = "joint"`, per-synthetic-node expected degree is predicted from the joint Poisson GLMs produced by `build_netparams(..., method = "joint")` in #61, and target statistics are aggregated via g-computation. This makes edges and every nodefactor target internally consistent by construction (`sum(nodefactor_<attr>) == 2 * edges` to machine precision).

Default `method = "existing"` is byte-identical to pre-refactor. Closes #62.

**Scope note:** This PR mixes surface area from #61 and #62. During review, PI pointed out that the concurrent target should also be joint-modeled — using a binomial GLM on the `deg > 1` indicator with the same joint RHS as the Poisson. That fit logically belongs in `build_netparams` (#61 territory) but its *use* is in `build_netstats` (#62). Fixing it split across two branches would have been awkward, so the joint concurrent binomial is included here as commit `cf558a6`.

**What `method = "joint"` does NOT yet cover** — these target stats still use univariate marginals and will be handled in #63 (extended to include dissolution/duration per PI request):
- `nodematch_age.grp`, `nodematch_race`, `nodematch_race_diffF`
- `absdiff_age`, `absdiff_sqrt.age`
- `nodematch(role.class)`
- `diss.homog`, `diss.byage` (durations / dissolution coefficients)

Until #63 lands, running `method = "joint"` end-to-end through EpiModelHIV-Template would mix joint and univariate sources in the ERGM target-stat vector — coherent enough for unit validation but not meaningful for a production estimation run.

## What's refactored under `method = "joint"`

| Field | Joint formula | Model |
|---|---|---|
| `edges` | `sum(pred) / 2` | Poisson joint |
| `nodefactor_race` | `sum(pred[race == r])` per level | Poisson joint |
| `nodefactor_age.grp` | `sum(pred[age.grp == k])` per level | Poisson joint |
| `nodefactor_deg.casl` (main) | `sum(pred[deg.casl == d])` per level | Poisson joint |
| `nodefactor_deg.main` (casl) | same pattern | Poisson joint |
| `nodefactor_deg.tot` (inst) | same pattern | Poisson joint |
| `nodefactor_diag.status` | `sum(pred[diag.status == h])` per level | Poisson joint |
| `concurrent` (main/casl) | `sum(pred_conc)` over synthetic nodes | **Binomial joint** on `deg > 1` |
| `nodematch_*`, `absdiff_*` | rescaled with new edges/nodefactor | (univariate ratio retained — see #63) |

## On `concurrent` specifically

First pass (commit `5ef9737`) retained `concurrent` from the univariate binomial because the Poisson-derived `P(deg > 1) = 1 - exp(-λ)(1+λ)` was inflated ~5× by the truncation of `deg.main` at 2 and `deg.casl` at 3 in the training data. The Poisson rejection was correct but the conclusion was wrong: the right fix is to joint-model the **binomial** on the concurrency indicator, same RHS as the Poisson, different family. Commit `cf558a6` does that:

- `fit_joint_poisson()` generalized to `fit_joint_glm(..., family = poisson())`
- Under `method = "joint"` in `build_netparams`, fit `glm(deg.<layer>.conc ~ <joint terms>, family = binomial())` and store at `netparams$<layer>$joint_concurrent_model` (main and casl only — inst has no concurrent target)
- Under `method = "joint"` in `build_netstats`, `out$<layer>$concurrent = sum(predict(joint_concurrent_model, synth, type = "response"))`

Empirical result (Atlanta, race = TRUE, N = 10k):
- main: existing 97.09 → joint 95.41 (-1.7%)
- casl: existing 1456.31 → joint 1614.05 (+10.8%)

Both in reasonable ranges — no Poisson-style inflation. Main barely moves because the univariate intercept-only fit already captures the population-average rate well; casl moves more because the AIC-selected `age.grp:deg.main` interaction captures real heterogeneity the univariate can't.

## Validation

**Backward-compat snapshot harness** (extended with `netstats_extra` + symmetric `method =`):

| Call | Result |
|---|---|
| `compare_to_snapshot()` (default) | **ALL MATCH** 3/3 |
| `compare_to_snapshot(method = "existing")` (now forwards to both) | **ALL MATCH** 3/3 |

**Internal consistency** (Atlanta, race = TRUE, N = 10k):

| Layer | `|2*edges − Σnf_race|` (existing) | under joint |
|---|---:|---:|
| main | 537 | **0.0** |
| casl | 319 | **0.0** |
| inst |  70 | **0.0** |

**Shifted target population** (`race.prop = c(0.35, 0.25, 0.40)`):

| Layer | existing edges | joint edges | Δ |
|---:|---:|---:|---:|
| main | 1990.3 | 1808.3 | −9.1% |
| casl | 2669.9 | 2929.2 | +9.7% |
| inst |  382.7 |  356.7 | −6.8% |

## Tests

- [`tests/testthat/test-joint-netstats.R`](tests/testthat/test-joint-netstats.R) — 7 blocks, 29 assertions.
- [`tests/testthat/test-joint-model.R`](tests/testthat/test-joint-model.R) — extended to 74 assertions (new: joint_concurrent_model presence + convergence + marginal recovery).
- All 103 assertions pass.

## Known minor (pre-existing, not a regression)

Dissolution-coefficient formulas capture the caller's scope environment. Under joint, that scope includes the `pred_deg_*` / `pred_conc_*` vectors (~10k doubles × 5), which silently bloats a serialized `netstats`. Consumers only use `$coef.diss`, so this is cosmetic — worth a follow-up if on-disk size matters.

## Test plan
- [x] Backward-compat snapshot match 3/3 (default + explicit `method = "existing"`)
- [x] Internal consistency to machine precision, all 3 layers, all nodefactor attrs
- [x] Joint ≠ existing under a shifted target population
- [x] Concurrent joint binomial: converges, recovers marginal, no inflation
- [x] Unit tests 103/103 total
- [ ] ~~End-to-end estimation with EpiModelHIV-Template using `method = "joint"`~~ — **deferred to after #63.** The netstats object is not yet coherently joint-driven: `nodematch_*`, `absdiff_*`, and dissolution terms still use univariate marginals. Running the end-to-end now would mix joint and univariate sources in the ERGM target-stat vector, which wouldn't be a meaningful validation of either. The real end-to-end run goes on the PR that lands #63.

Depends on #61 (merged). Unblocks #63, #64, #65.